### PR TITLE
Feature/setnewidroot

### DIFF
--- a/cmd/relay/endpoint/claim.go
+++ b/cmd/relay/endpoint/claim.go
@@ -1,6 +1,7 @@
 package endpoint
 
 import (
+	"bytes"
 	"errors"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -12,6 +13,51 @@ import (
 	"github.com/iden3/go-iden3/merkletree"
 )
 
+func handlePostNewIDRoot(c *gin.Context) {
+	idaddrhex := c.Param("idaddr")
+	idaddr := common.HexToAddress(idaddrhex)
+
+	var setRootMsg claimsrv.SetRootMsg
+	c.BindJSON(&setRootMsg)
+
+	idaddrMsg := common.HexToAddress(setRootMsg.IdAddr)
+	kSign := common.HexToAddress(setRootMsg.KSign)
+	// make sure that the given idaddr from the post url matches with the idaddr from the post data
+	if !bytes.Equal(idaddr.Bytes(), idaddrMsg.Bytes()) {
+		fail(c, "error on PostNewRoot, idaddr not match", errors.New("PostNewRoot idaddr not match"))
+		return
+	}
+	// get signature from setRootClaimMsg
+	signature, err := common3.HexToBytes(setRootMsg.Signature)
+	if err != nil {
+		fail(c, "error on PostNewRoot parse signature", err)
+		return
+	}
+	rootBytes, err := common3.HexToBytes(setRootMsg.Root)
+	if err != nil {
+		fail(c, "error on PostNewRoot parse root", err)
+		return
+	}
+	var root merkletree.Hash
+	copy(root[:], rootBytes[:32])
+
+	// signature of idaddr+root+timestamp, only valid if is from last X seconds
+	setRootClaim, err := claimservice.SetNewIDRoot(idaddr, kSign, root, setRootMsg.Timestamp, signature)
+	if err != nil {
+		fail(c, "error on AddAuthorizeKSignClaim", err)
+		return
+	}
+
+	// return claim with proofs
+	proofOfClaim, err := claimservice.GetClaimByHi(idaddr, setRootClaim.Hi())
+	if err != nil {
+		fail(c, "error on GetClaimByHi", err)
+		return
+	}
+	c.JSON(200, gin.H{
+		"proofOfClaim": proofOfClaim.Hex(),
+	})
+}
 func handlePostClaim(c *gin.Context) {
 	idaddrhex := c.Param("idaddr")
 	idaddr := common.HexToAddress(idaddrhex)

--- a/cmd/relay/endpoint/serve.go
+++ b/cmd/relay/endpoint/serve.go
@@ -35,6 +35,7 @@ func serveServiceApi() *http.Server {
 
 	serviceapi.GET("/root", handleGetRoot)
 
+	serviceapi.POST("/root/:idaddr", handlePostNewIDRoot)
 	serviceapi.POST("/claim/:idaddr", handlePostClaim)
 	serviceapi.GET("/claim/:idaddr/root", handleGetIDRoot)
 	serviceapi.GET("/claim/:idaddr/hi/:hi", handleGetClaimByHi)

--- a/cmd/relay/endpoint/serve.go
+++ b/cmd/relay/endpoint/serve.go
@@ -35,7 +35,7 @@ func serveServiceApi() *http.Server {
 
 	serviceapi.GET("/root", handleGetRoot)
 
-	serviceapi.POST("/root/:idaddr", handlePostNewIDRoot)
+	serviceapi.POST("/root/:idaddr", handleCommitNewIDRoot)
 	serviceapi.POST("/claim/:idaddr", handlePostClaim)
 	serviceapi.GET("/claim/:idaddr/root", handleGetIDRoot)
 	serviceapi.GET("/claim/:idaddr/hi/:hi", handleGetClaimByHi)

--- a/services/centrauthsrv/challenge.go
+++ b/services/centrauthsrv/challenge.go
@@ -23,7 +23,7 @@ func VerifyChallengeTimestamp(challenge string) error {
 	// if elapsed.Seconds() > 30000 { // 30 seconds to resolve challenge // DEV in development we use more time
 	// 	return errors.New("VerifyTimstamp: too much time elapsed since the challenge was sent")
 	// }
-	verified := utils.VerifyTimestamp(unixTimeChallenge, 30000) // 30 seconds to resolve challenge // DEV in development we use more time
+	verified := utils.VerifyTimestamp(uint64(unixTimeChallenge), 30000) // 30 seconds to resolve challenge // DEV in development we use more time
 	if !verified {
 		return errors.New("VerifyTimstamp: too much time elapsed since the challenge was sent")
 	}

--- a/services/centrauthsrv/challenge.go
+++ b/services/centrauthsrv/challenge.go
@@ -4,22 +4,27 @@ import (
 	"errors"
 	"strconv"
 	"strings"
-	"time"
+
+	"github.com/iden3/go-iden3/utils"
 )
 
-// VerifyTimestamp checks that the given timestamp is correct
-func VerifyTimestamp(challenge string) error {
+// VerifyChallengeTimestamp checks that the given timestamp is correct
+func VerifyChallengeTimestamp(challenge string) error {
 	// verify challenge timestamp < 30 seconds ago
 	if len(strings.Split(challenge, "-")) < 2 {
-		return errors.New("VerifyTimestamp: challenge timestamp error")
+		return errors.New("VerifyChallengeTimestamp: challenge timestamp error")
 	}
 	unixTimeChallenge, err := strconv.Atoi(strings.Split(challenge, "-")[1])
 	if err != nil {
-		return errors.New("VerifyTimestamp: challenge timestamp error")
+		return errors.New("VerifyChallengeTimestamp: challenge timestamp error")
 	}
-	t := time.Unix(int64(unixTimeChallenge), 10)
-	elapsed := time.Since(t)
-	if elapsed.Seconds() > 30000 { // 30 seconds to resolve challenge // DEV in development we use more time
+	// t := time.Unix(int64(unixTimeChallenge), 10)
+	// elapsed := time.Since(t)
+	// if elapsed.Seconds() > 30000 { // 30 seconds to resolve challenge // DEV in development we use more time
+	// 	return errors.New("VerifyTimstamp: too much time elapsed since the challenge was sent")
+	// }
+	verified := utils.VerifyTimestamp(unixTimeChallenge, 30000) // 30 seconds to resolve challenge // DEV in development we use more time
+	if !verified {
 		return errors.New("VerifyTimstamp: too much time elapsed since the challenge was sent")
 	}
 	return nil

--- a/services/centrauthsrv/challenge_test.go
+++ b/services/centrauthsrv/challenge_test.go
@@ -6,9 +6,9 @@ import (
 	"time"
 )
 
-func TestVerifyTimestamp(t *testing.T) {
+func TestVerifyChallengeTimestamp(t *testing.T) {
 	challenge := "uuid-" + strconv.Itoa(int(time.Now().Unix())) + "-randstr"
-	err := VerifyTimestamp(challenge)
+	err := VerifyChallengeTimestamp(challenge)
 	if err != nil {
 		t.Errorf(err.Error())
 	}

--- a/services/centrauthsrv/service.go
+++ b/services/centrauthsrv/service.go
@@ -11,7 +11,7 @@ import (
 
 // Auth validates that the given AuthMsg data matches the requirments
 func Auth(authMsg AuthMsg) error {
-	err := VerifyTimestamp(authMsg.Challenge)
+	err := VerifyChallengeTimestamp(authMsg.Challenge)
 	if err != nil {
 		return err
 	}

--- a/services/claimsrv/messages.go
+++ b/services/claimsrv/messages.go
@@ -33,10 +33,13 @@ type AuthorizeKSignClaimMsg struct {
 	KSign               common.Address
 }
 
-// SetRootClaimMsg contains a core.SetRootClaim with its signature in Hex
-type SetRootClaimMsg struct {
-	SetRootClaim core.SetRootClaim
-	Signature    string
+// SetRootMsg contains the data to set the SetRootClaim with its signature in Hex
+type SetRootMsg struct {
+	Root      string
+	IdAddr    string
+	KSign     string
+	Timestamp uint64
+	Signature string
 }
 
 // ClaimValueMsg contains a core.ClaimValue with its signature in Hex

--- a/services/claimsrv/service.go
+++ b/services/claimsrv/service.go
@@ -18,6 +18,7 @@ import (
 var ErrNotFound = errors.New("value not found")
 
 type Service interface {
+	SetNewIDRoot(idaddr common.Address, kSign common.Address, root merkletree.Hash, timestamp uint64, signature []byte) (core.SetRootClaim, error)
 	AddAssignNameClaim(assignNameClaim core.AssignNameClaim) error
 	AddAuthorizeKSignClaim(ethID common.Address, authorizeKSignClaimMsg AuthorizeKSignClaimMsg) error
 	AddAuthorizeKSignClaimFirst(ethID common.Address, authorizeKSignClaim core.AuthorizeKSignClaim) error
@@ -36,6 +37,65 @@ type ServiceImpl struct {
 
 func New(mt *merkletree.MerkleTree, rootsrv rootsrv.Service, signer signsrv.Service) *ServiceImpl {
 	return &ServiceImpl{mt, rootsrv, signer}
+}
+
+func (cs *ServiceImpl) SetNewIDRoot(idaddr common.Address, kSign common.Address, root merkletree.Hash, timestamp uint64, signature []byte) (core.SetRootClaim, error) {
+	// get the user's id storage, using the user id prefix (the idaddress itself)
+	stoUserID := cs.mt.Storage().WithPrefix(idaddr.Bytes())
+
+	// open the MerkleTree of the user
+	userMT, err := merkletree.New(stoUserID, 140)
+	if err != nil {
+		return core.SetRootClaim{}, err
+	}
+
+	// verify that the KSign is authorized
+	if !CheckKSignInIDdb(userMT, kSign) {
+		return core.SetRootClaim{}, errors.New("can not verify the KSign")
+	}
+	// in the future the user merkletree will be in the client side, and this step will be a check of the ProofOfKSign
+
+	// check data timestamp
+	verified := utils.VerifyTimestamp(timestamp, 30000)
+	if !verified {
+		return core.SetRootClaim{}, errors.New("timestamp too old")
+	}
+	// check signature with idaddr
+	// whee data signed is idaddr+root+timestamp
+	timestampBytes, err := core.Uint64ToEthBytes(timestamp)
+	if err != nil {
+		return core.SetRootClaim{}, err
+	}
+	var msg []byte
+	msg = append(msg, idaddr.Bytes()...)
+	msg = append(msg, root.Bytes()...)
+	msg = append(msg, timestampBytes...)
+
+	msgHash := utils.EthHash(msg)
+	signature[64] -= 27
+	if !utils.VerifySig(kSign, signature, msgHash[:]) {
+		return core.SetRootClaim{}, errors.New("signature can not be verified")
+	}
+
+	// setRootClaim of the user in the Relay Merkle Tree
+	// create new SetRootClaim
+	setRootClaim := core.NewSetRootClaim(idaddr, root)
+	version, err := GetNextVersion(cs.mt, setRootClaim.Hi())
+	if err != nil {
+		return core.SetRootClaim{}, err
+	}
+	setRootClaim.BaseIndex.Version = version
+
+	// add User's ID Merkle Root into the Relay's Merkle Tree
+	err = cs.mt.Add(setRootClaim)
+	if err != nil {
+		return core.SetRootClaim{}, err
+	}
+
+	// update Relay Root in Smart Contract
+	cs.rootsrv.SetRoot(cs.mt.Root())
+
+	return setRootClaim, nil
 }
 
 // AddAssignNameClaim adds AssignNameClaim into the merkletree, updates the root in the smart contract, and returns the merkle proof of the claim in the merkletree

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"bytes"
 	"encoding/json"
+	"time"
 
 	"github.com/iden3/go-iden3/merkletree"
 )
@@ -38,4 +39,13 @@ func PoW(data PoWData, difficulty int) (PoWData, error) {
 		hash = merkletree.HashBytes(b)
 	}
 	return data, nil
+}
+
+func VerifyTimestamp(timestamp uint64, timelimit int) bool {
+	t := time.Unix(int64(timestamp), 10)
+	elapsed := time.Since(t)
+	if int(elapsed.Seconds()) > timelimit {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
- added claimsrv.CommitNewIDRoot, that checks that the data is valid (key ksign valid, timestamp, signature)
- added relay endpoint `POST /root/:idaddr` to commit identities merkletrees roots

current version is for the version where the user merkletree is in the backend side. Next version will be with the user merkletree in the client side