### PR TITLE
Adds relay cli to add Generic claims manually and import multiple Gen…

### DIFF
--- a/cmd/relay/commands/claim.go
+++ b/cmd/relay/commands/claim.go
@@ -1,0 +1,139 @@
+package commands
+
+import (
+	"bufio"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"os"
+
+	cfg "github.com/iden3/go-iden3/cmd/relay/config"
+	common3 "github.com/iden3/go-iden3/common"
+	"github.com/iden3/go-iden3/core"
+	log "github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+)
+
+var ClaimCommands = []cli.Command{
+	{
+		Name:  "claim",
+		Usage: "claim add",
+		Subcommands: []cli.Command{{
+			Name:   "add",
+			Usage:  "claim add",
+			Action: cmdAddClaim,
+		}},
+	},
+	{
+		Name:  "claims",
+		Usage: "claims import from file",
+		Subcommands: []cli.Command{{
+			Name:   "fromfile",
+			Usage:  "import claims from file",
+			Action: cmdAddClaimsFromFile,
+		}},
+	},
+}
+
+func cmdAddClaim(c *cli.Context) error {
+	if err := cfg.MustRead(c); err != nil {
+		return err
+	}
+
+	ks, acc := cfg.LoadKeyStore()
+	client := cfg.LoadWeb3(ks, &acc)
+	storage := cfg.LoadStorage()
+	mt := cfg.LoadMerkele(storage)
+
+	rootservice := cfg.LoadRootsService(client)
+	claimservice := cfg.LoadClaimService(mt, rootservice, ks, acc)
+
+	indexData := c.Args().Get(0)
+	outData := c.Args().Get(1)
+
+	claim := core.NewGenericClaim("iden3.io", "generic", []byte(indexData), []byte(outData))
+	fmt.Println("clam: " + common3.BytesToHex(claim.Bytes()))
+
+	err := claimservice.AddDirectClaim(claim)
+	if err != nil {
+		return err
+	}
+	fmt.Print("root updated: " + mt.Root().Hex())
+
+	mp, err := mt.GenerateProof(claim.Hi())
+	if err != nil {
+		return err
+	}
+	fmt.Print("merkleproof: " + common3.BytesToHex(mp))
+
+	return nil
+}
+
+func cmdAddClaimsFromFile(c *cli.Context) error {
+	if err := cfg.MustRead(c); err != nil {
+		return err
+	}
+	// read config
+	filepath := c.Args().Get(0)
+
+	ks, acc := cfg.LoadKeyStore()
+	client := cfg.LoadWeb3(ks, &acc)
+	storage := cfg.LoadStorage()
+	mt := cfg.LoadMerkele(storage)
+
+	rootservice := cfg.LoadRootsService(client)
+
+	fmt.Print("\n---\nimporting claims\n---\n\n")
+	// csv file will have the following structure: indexData, noindexData
+	csvFile, _ := os.Open(filepath)
+	reader := csv.NewReader(bufio.NewReader(csvFile))
+	var err error
+	for {
+		line, error := reader.Read()
+		if error == io.EOF {
+			break
+		} else if error != nil {
+			log.Fatal(error)
+		}
+
+		fmt.Println("importing claim with index: " + line[0] + ", outside index: " + line[1])
+
+		claim := core.NewGenericClaim("iden3.io", "generic", []byte(line[0]), []byte(line[1]))
+		fmt.Println("clam: " + common3.BytesToHex(claim.Bytes()) + "\n")
+
+		// add claim to merkletree, without updating the root, that will be done on the end of the loop (csv file)
+		err = mt.Add(claim)
+		if err != nil {
+			return err
+		}
+	}
+	fmt.Print("\n---\ngenerating proofs\n---\n\n")
+	// now, let's generate the proofs
+	csvFile, _ = os.Open(filepath)
+	reader = csv.NewReader(bufio.NewReader(csvFile))
+	for {
+		line, error := reader.Read()
+		if error == io.EOF {
+			break
+		} else if error != nil {
+			log.Fatal(error)
+		}
+
+		fmt.Println("generating merkleproof of claim with index: " + line[0] + ", outside index: " + line[1])
+
+		claim := core.NewGenericClaim("iden3.io", "generic", []byte(line[0]), []byte(line[1]))
+		fmt.Println("clam: " + common3.BytesToHex(claim.Bytes()))
+
+		// the proofs better generate them once all claims are added
+		mp, err := mt.GenerateProof(claim.Hi())
+		if err != nil {
+			return err
+		}
+		fmt.Println("merkleproof: " + common3.BytesToHex(mp) + "\n")
+	}
+	// update the root in the smart contract
+	rootservice.SetRoot(mt.Root())
+	fmt.Println("merkletree root: " + mt.Root().Hex())
+
+	return nil
+}

--- a/cmd/relay/endpoint/claim.go
+++ b/cmd/relay/endpoint/claim.go
@@ -73,15 +73,15 @@ func handlePostClaim(c *gin.Context) {
 	typeBytes := bytesValue[32:56]
 
 	switch common3.BytesToHex(typeBytes) {
-	case common3.BytesToHex(core.DefaultType):
-		claimDefault, err := core.ParseGenericClaimBytes(bytesValue)
+	case common3.BytesToHex(core.GenericType):
+		claimGeneric, err := core.ParseGenericClaimBytes(bytesValue)
 		if err != nil {
 			fail(c, "error on parsing GenericClaim bytes", err)
 			return
 		}
 
 		claimValueMsg := claimsrv.ClaimValueMsg{
-			claimDefault,
+			claimGeneric,
 			bytesSignedMsg.SignatureHex,
 			bytesSignedMsg.KSign,
 		}
@@ -91,7 +91,7 @@ func handlePostClaim(c *gin.Context) {
 			return
 		}
 		// return claim with proofs
-		proofOfClaim, err := claimservice.GetClaimByHi(idaddr, claimDefault.Hi())
+		proofOfClaim, err := claimservice.GetClaimByHi(idaddr, claimGeneric.Hi())
 		if err != nil {
 			fail(c, "error on GetClaimByHi", err)
 			return

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -23,6 +23,7 @@ func main() {
 	app.Commands = append(app.Commands, commands.IdCommands...)
 	app.Commands = append(app.Commands, commands.ContractCommands...)
 	app.Commands = append(app.Commands, commands.DbCommands...)
+	app.Commands = append(app.Commands, commands.ClaimCommands...)
 
 	err := app.Run(os.Args)
 	if err != nil {

--- a/core/claim.go
+++ b/core/claim.go
@@ -17,7 +17,7 @@ var (
 	authorizeksignTypeHash = merkletree.HashBytes([]byte("authorizeksign"))
 	setRootTypeHash        = merkletree.HashBytes([]byte("setroot"))
 
-	DefaultType        = defaultTypeHash[:24]
+	GenericType        = defaultTypeHash[:24]
 	AssignNameType     = assignNameTypeHash[:24]
 	AuthorizeksignType = authorizeksignTypeHash[:24]
 	SetRootType        = setRootTypeHash[:24]
@@ -324,7 +324,7 @@ func ParseTypeClaimBytes(b []byte) (string, error) {
 		return "", errors.New("claim.BaseIndex.IndexLength can not be bigger than claim bytes length")
 	}
 	typeBytes := b[32:56]
-	if bytes.Equal(DefaultType, typeBytes) {
+	if bytes.Equal(GenericType, typeBytes) {
 		return "default", nil
 	} else if bytes.Equal(AssignNameType, typeBytes) {
 		return "assignname", nil
@@ -345,7 +345,7 @@ func ParseValueFromBytes(b []byte) (merkletree.Value, error) {
 	var value merkletree.Value
 	var err error
 	switch typeBytes {
-	case common3.BytesToHex(DefaultType):
+	case common3.BytesToHex(GenericType):
 		value, err = ParseGenericClaimBytes(b)
 		break
 	case common3.BytesToHex(AssignNameType):

--- a/services/claimsrv/service.go
+++ b/services/claimsrv/service.go
@@ -23,6 +23,7 @@ type Service interface {
 	AddAuthorizeKSignClaim(ethID common.Address, authorizeKSignClaimMsg AuthorizeKSignClaimMsg) error
 	AddAuthorizeKSignClaimFirst(ethID common.Address, authorizeKSignClaim core.AuthorizeKSignClaim) error
 	AddUserIDClaim(ethID common.Address, claimValueMsg ClaimValueMsg) error
+	AddDirectClaim(claim core.GenericClaim) error
 	GetIDRoot(ethID common.Address) (merkletree.Hash, []byte, error)
 	GetClaimByHi(ethID common.Address, hi merkletree.Hash) (ProofOfClaim, error)
 	GetRelayClaimByHi(hi merkletree.Hash) (ProofOfRelayClaim, error)
@@ -270,6 +271,16 @@ func (cs *ServiceImpl) AddUserIDClaim(ethID common.Address, claimValueMsg ClaimV
 	// update Relay Root in Smart Contract
 	cs.rootsrv.SetRoot(cs.mt.Root())
 
+	return nil
+}
+
+// AddDirectClaim adds a claim directly to the Relay merkletree
+func (cs *ServiceImpl) AddDirectClaim(claim core.GenericClaim) error {
+	err := cs.mt.Add(claim)
+	if err != nil {
+		return err
+	}
+	cs.rootsrv.SetRoot(cs.mt.Root())
 	return nil
 }
 


### PR DESCRIPTION
…eric claims from a csv file

relay cli to add claims manually (cmdAddClaim)

cli add claim, print claim, root, merkleproof

cmdAddClaimsFromFile WIP

relay cli, import generic claims from csv file