### PR TITLE
Move generic hash out of merkletree module

### DIFF
--- a/core/claim.go
+++ b/core/claim.go
@@ -9,28 +9,29 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	common3 "github.com/iden3/go-iden3/common"
 	"github.com/iden3/go-iden3/merkletree"
+	"github.com/iden3/go-iden3/utils"
 )
 
 var (
-	defaultTypeHash        = merkletree.HashBytes([]byte("default"))
-	assignNameTypeHash     = merkletree.HashBytes([]byte("assignname"))
-	authorizeksignTypeHash = merkletree.HashBytes([]byte("authorizeksign"))
-	setRootTypeHash        = merkletree.HashBytes([]byte("setroot"))
+	defaultTypeHash        = utils.HashBytes([]byte("default"))
+	assignNameTypeHash     = utils.HashBytes([]byte("assignname"))
+	authorizeksignTypeHash = utils.HashBytes([]byte("authorizeksign"))
+	setRootTypeHash        = utils.HashBytes([]byte("setroot"))
 
 	GenericType        = defaultTypeHash[:24]
 	AssignNameType     = assignNameTypeHash[:24]
 	AuthorizeksignType = authorizeksignTypeHash[:24]
 	SetRootType        = setRootTypeHash[:24]
 
-	NamespaceHash = merkletree.HashBytes([]byte("iden3.io"))
+	NamespaceHash = utils.HashBytes([]byte("iden3.io"))
 )
 
 // BaseIndex is the by default parameters of the index of every Claim
 type BaseIndex struct {
-	Namespace   merkletree.Hash // keccak("iden3.io")
-	Type        [24]byte        // claim type, keccak("<spec>") [32:56]
-	IndexLength uint32          // [4]byte
-	Version     uint32          // [4] byte
+	Namespace   utils.Hash // keccak("iden3.io")
+	Type        [24]byte   // claim type, keccak("<spec>") [32:56]
+	IndexLength uint32     // [4]byte
+	Version     uint32     // [4] byte
 }
 
 // GenericClaim is a default data structure of a claim
@@ -46,8 +47,8 @@ type GenericClaim struct {
 type AssignNameClaim struct {
 	BaseIndex
 	ExtraIndex struct {
-		Name   merkletree.Hash // keccak("bob")
-		Domain merkletree.Hash // ens_namehash("barcelona.eth")
+		Name   utils.Hash // keccak("bob")
+		Domain utils.Hash // ens_namehash("barcelona.eth")
 	}
 	EthID common.Address // EthID address of identity
 }
@@ -58,8 +59,8 @@ type AuthorizeKSignClaim struct {
 	ExtraIndex struct {
 		KeyToAuthorize common.Address
 	}
-	Application      merkletree.Hash
-	ApplicationAuthz merkletree.Hash
+	Application      utils.Hash
+	ApplicationAuthz utils.Hash
 	ValidFrom        uint64
 	ValidUntil       uint64
 }
@@ -110,7 +111,7 @@ func (c GenericClaim) IndexLength() uint32 {
 // Hi returns the hash of the index of the claim
 func (c GenericClaim) Hi() merkletree.Hash {
 	h := merkletree.HashBytes(c.Bytes()[:c.BaseIndex.IndexLength])
-	// h := merkletree.HashBytes(c.Bytes())
+	// h := utils.HashBytes(c.Bytes())
 	return h
 }
 
@@ -176,7 +177,7 @@ func (c AssignNameClaim) Hi() merkletree.Hash {
 	// bytesIndex = append(bytesIndex, versionBytes[:]...)
 	// bytesIndex = append(bytesIndex, c.ExtraIndex.Name[:]...)
 	// bytesIndex = append(bytesIndex, c.ExtraIndex.Domain[:]...)
-	// h := merkletree.HashBytes(bytesIndex)
+	// h := utils.HashBytes(bytesIndex)
 	h := merkletree.HashBytes(c.Bytes()[:c.BaseIndex.IndexLength])
 	return h
 }
@@ -242,7 +243,7 @@ func (c AuthorizeKSignClaim) IndexLength() uint32 {
 
 // Hi returns the hash of the index of the claim
 func (c AuthorizeKSignClaim) Hi() merkletree.Hash {
-	// return merkletree.HashBytes(c.indexBytes())
+	// return utils.HashBytes(c.indexBytes())
 	return merkletree.HashBytes(c.Bytes()[:c.BaseIndex.IndexLength])
 }
 
@@ -304,7 +305,7 @@ func (c SetRootClaim) Hi() merkletree.Hash {
 	// versionBytes, _ := Uint32ToEthBytes(c.BaseIndex.Version)
 	// bytesIndex = append(bytesIndex, versionBytes[:]...)
 	// bytesIndex = append(bytesIndex, c.ExtraIndex.EthID[:]...)
-	// h := merkletree.HashBytes(bytesIndex)
+	// h := utils.HashBytes(bytesIndex)
 	h := merkletree.HashBytes(c.Bytes()[:c.BaseIndex.IndexLength])
 	return h
 }
@@ -368,8 +369,8 @@ func ParseValueFromBytes(b []byte) (merkletree.Value, error) {
 // NewGenericClaim returns a GenericClaim object with the given parameters
 func NewGenericClaim(namespaceStr, typeStr string, extraIndexData []byte, data []byte) GenericClaim {
 	var c GenericClaim
-	c.BaseIndex.Namespace = merkletree.HashBytes([]byte(namespaceStr))
-	typeHash := merkletree.HashBytes([]byte(typeStr))
+	c.BaseIndex.Namespace = utils.HashBytes([]byte(namespaceStr))
+	typeHash := utils.HashBytes([]byte(typeStr))
 	copy(c.BaseIndex.Type[:], typeHash[:24])
 	c.BaseIndex.IndexLength = 64 + uint32(len(extraIndexData))
 	c.BaseIndex.Version = 0
@@ -379,7 +380,7 @@ func NewGenericClaim(namespaceStr, typeStr string, extraIndexData []byte, data [
 }
 
 // NewAssignNameClaim returns a AssignNameClaim object with the given parameters
-func NewAssignNameClaim(name, domain merkletree.Hash, ethID common.Address) AssignNameClaim {
+func NewAssignNameClaim(name, domain utils.Hash, ethID common.Address) AssignNameClaim {
 	var c AssignNameClaim
 	c.BaseIndex.Namespace = NamespaceHash
 	copy(c.BaseIndex.Type[:], AssignNameType)
@@ -399,8 +400,8 @@ func NewAuthorizeKSignClaim(keyToAuthorize common.Address, applicationName, appl
 	c.BaseIndex.IndexLength = 84
 	c.BaseIndex.Version = 0
 	c.ExtraIndex.KeyToAuthorize = keyToAuthorize
-	c.Application = merkletree.HashBytes([]byte(applicationName))
-	c.ApplicationAuthz = merkletree.HashBytes([]byte(applicationAuthz))
+	c.Application = utils.HashBytes([]byte(applicationName))
+	c.ApplicationAuthz = utils.HashBytes([]byte(applicationAuthz))
 	c.ValidFrom = validFrom
 	c.ValidUntil = validUntil
 	return c
@@ -413,8 +414,8 @@ func NewOperationalKSignClaim(keyToAuthorize common.Address) AuthorizeKSignClaim
 	c.BaseIndex.IndexLength = 84
 	c.BaseIndex.Version = 0
 	c.ExtraIndex.KeyToAuthorize = keyToAuthorize
-	c.Application = merkletree.Hash{}
-	c.ApplicationAuthz = merkletree.Hash{}
+	c.Application = utils.Hash{}
+	c.ApplicationAuthz = utils.Hash{}
 	c.ValidFrom = 0
 	c.ValidUntil = math.MaxUint64
 	return c

--- a/core/claim_test.go
+++ b/core/claim_test.go
@@ -9,6 +9,7 @@ import (
 	common3 "github.com/iden3/go-iden3/common"
 	"github.com/iden3/go-iden3/db"
 	"github.com/iden3/go-iden3/merkletree"
+	"github.com/iden3/go-iden3/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -60,7 +61,7 @@ func TestClaimGenerationAndParse(t *testing.T) {
 }
 
 func TestAssignNameClaim(t *testing.T) {
-	assignNameClaim := NewAssignNameClaim(merkletree.HashBytes([]byte("john")), merkletree.HashBytes([]byte("iden3.io")), common.HexToAddress("0x101d2fa51f8259df207115af9eaa73f3f4e52e60"))
+	assignNameClaim := NewAssignNameClaim(utils.HashBytes([]byte("john")), utils.HashBytes([]byte("iden3.io")), common.HexToAddress("0x101d2fa51f8259df207115af9eaa73f3f4e52e60"))
 	assignNameClaimParsed, err := ParseAssignNameClaimBytes(assignNameClaim.Bytes())
 	assert.Nil(t, err)
 	if !bytes.Equal(assignNameClaimParsed.Bytes(), assignNameClaim.Bytes()) {

--- a/merkletree/merkletreeSpecification_test.go
+++ b/merkletree/merkletreeSpecification_test.go
@@ -26,7 +26,7 @@ func (c testBytesClaim) IndexLength() uint32 {
 	return c.indexLength
 }
 func (c testBytesClaim) Hi() Hash {
-	h := HashBytes(c.Bytes()[:c.IndexLength()])
+	h := hashBytes(c.Bytes()[:c.IndexLength()])
 	return h
 }
 func newTestBytesClaim(data string, indexLength uint32) testBytesClaim {
@@ -38,10 +38,10 @@ func newTestBytesClaim(data string, indexLength uint32) testBytesClaim {
 
 // Test to check the iden3-merkletree-specification
 func TestIden3MerkletreeSpecification(t *testing.T) {
-	h := HashBytes([]byte("test")).Hex()
+	h := hashBytes([]byte("test")).Hex()
 	assert.Equal(t, "0x9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658", h)
 
-	h = HashBytes([]byte("authorizeksign")).Hex()
+	h = hashBytes([]byte("authorizeksign")).Hex()
 	assert.Equal(t, "0x353f867ef725411de05e3d4b0a01c37cf7ad24bcc213141a05ed7726d7932a1f", h)
 
 	mt := newTestingMerkle(t, 140)
@@ -123,7 +123,7 @@ func TestIden3MerkletreeSpecification(t *testing.T) {
 	assert.True(t, verified)
 
 	// check the proof generated in the previous steps
-	verified = CheckProof(mt.Root(), proof2, claim2.Hi(), HashBytes(claim2.Bytes()), 140)
+	verified = CheckProof(mt.Root(), proof2, claim2.Hi(), hashBytes(claim2.Bytes()), 140)
 	assert.True(t, verified)
 	// check proof of no existence (emptyLeaf), as we are prooving an empty leaf, the Ht is an empty value (0x000...0)
 	verified = CheckProof(mt.Root(), proof3, claim3.Hi(), EmptyNodeValue, 140)

--- a/merkletree/merkletree_test.go
+++ b/merkletree/merkletree_test.go
@@ -48,14 +48,14 @@ func (c testClaim) IndexLength() uint32 {
 	return uint32(len(c.Bytes()))
 }
 func (c testClaim) hi() Hash {
-	h := HashBytes(c.Bytes())
+	h := hashBytes(c.Bytes())
 	return h
 }
 func newTestClaim(namespaceStr, typeStr string, data []byte) testClaim {
 	var c testClaim
 	c.testBase.Length = [4]byte{0x00, 0x00, 0x00, 0x48}
-	c.testBase.Namespace = HashBytes([]byte(namespaceStr))
-	c.testBase.Type = HashBytes([]byte(typeStr))
+	c.testBase.Namespace = hashBytes([]byte(namespaceStr))
+	c.testBase.Type = hashBytes([]byte(typeStr))
 	c.testBase.Version = 0
 	c.extraIndex.Data = data
 	return c
@@ -204,7 +204,7 @@ func TestCheckProof(t *testing.T) {
 
 	mp, err := mt.GenerateProof(parseTestClaimBytes(claim1.Bytes()).hi())
 	assert.Nil(t, err)
-	verified := CheckProof(mt.Root(), mp, claim1.hi(), HashBytes(claim1.Bytes()), mt.NumLevels())
+	verified := CheckProof(mt.Root(), mp, claim1.hi(), hashBytes(claim1.Bytes()), mt.NumLevels())
 	assert.True(t, verified)
 
 }
@@ -310,8 +310,8 @@ func TestVector4(t *testing.T) {
 	assert.Nil(t, mt.Add(vt{zeros, uint32(1)}))
 	v := vt{zeros, uint32(2)}
 	assert.Nil(t, mt.Add(v))
-	proof, _ := mt.GenerateProof(HashBytes(v.Bytes()[:v.IndexLength()]))
-	assert.True(t, CheckProof(mt.Root(), proof, HashBytes(v.Bytes()[:v.IndexLength()]), HashBytes(v.Bytes()), mt.NumLevels()))
+	proof, _ := mt.GenerateProof(hashBytes(v.Bytes()[:v.IndexLength()]))
+	assert.True(t, CheckProof(mt.Root(), proof, hashBytes(v.Bytes()[:v.IndexLength()]), hashBytes(v.Bytes()), mt.NumLevels()))
 	assert.Equal(t, 4, mt.NumLevels())
 	assert.Equal(t, "0000000000000000000000000000000000000000000000000000000000000001", hex.EncodeToString(v.Bytes()))
 	assert.Equal(t, "0xc1b95ffbb999a6dd7a472a610a98891ffae95cc973d1d1e21acfdd68db830b51", mt.Root().Hex())
@@ -327,9 +327,9 @@ func TestVector140(t *testing.T) {
 	for i := 1; i < len(zeros)-1; i++ {
 		v := vt{zeros, uint32(i)}
 		assert.Nil(t, mt.Add(v))
-		proof, err := mt.GenerateProof(HashBytes(v.Bytes()[:v.IndexLength()]))
+		proof, err := mt.GenerateProof(hashBytes(v.Bytes()[:v.IndexLength()]))
 		assert.Nil(t, err)
-		assert.True(t, CheckProof(mt.Root(), proof, HashBytes(v.Bytes()[:v.IndexLength()]), HashBytes(v.Bytes()), mt.NumLevels()))
+		assert.True(t, CheckProof(mt.Root(), proof, hashBytes(v.Bytes()[:v.IndexLength()]), hashBytes(v.Bytes()), mt.NumLevels()))
 		if i == len(zeros)-2 {
 			assert.Equal(t, 140, mt.NumLevels())
 			assert.Equal(t, uint32(30), v.IndexLength())

--- a/merkletree/node.go
+++ b/merkletree/node.go
@@ -17,7 +17,7 @@ func (n *treeNode) Bytes() (b []byte) {
 
 // Ht returns the hash of the full node
 func (n *treeNode) Ht() Hash {
-	h := HashBytes(n.Bytes())
+	h := hashBytes(n.Bytes())
 	return h
 }
 

--- a/merkletree/print.go
+++ b/merkletree/print.go
@@ -33,8 +33,8 @@ func (mt *MerkleTree) printLevel(parent Hash, iLevel int, maxLevel int) {
 	} else if nodeType == byte(finalNodeType) { //typ==FINAL_NODE
 		// claim := core.ParseClaimDefaultBytes(nodeBytes)
 		fmt.Print("[FinalTree]:")
-		color.Cyan("final tree node: " + HashBytes(nodeBytes).Hex())
-		_, _, leafNodeBytes, err := mt.dbGet(HashBytes(nodeBytes))
+		color.Cyan("final tree node: " + hashBytes(nodeBytes).Hex())
+		_, _, leafNodeBytes, err := mt.dbGet(hashBytes(nodeBytes))
 		if err != nil {
 			color.Red(err.Error())
 		}

--- a/merkletree/utils.go
+++ b/merkletree/utils.go
@@ -19,8 +19,15 @@ func (hash Hash) Bytes() []byte {
 	return hash[:]
 }
 
-// HashBytes performs a Keccak256 hash over the bytes
+// HashBytes is a placeholder temorary function for the transition to the new Merklee Tree
 func HashBytes(b []byte) (hash Hash) {
+	h := crypto.Keccak256(b)
+	copy(hash[:], h)
+	return hash
+}
+
+// hashBytes performs a Keccak256 hash over the bytes
+func hashBytes(b []byte) (hash Hash) {
 	h := crypto.Keccak256(b)
 	copy(hash[:], h)
 	return hash

--- a/merkletree/utils_test.go
+++ b/merkletree/utils_test.go
@@ -24,9 +24,9 @@ func TestGetSetBitmap(t *testing.T) {
 }
 
 func TestHashBytes(t *testing.T) {
-	h := HashBytes([]byte("test")).Hex()
+	h := hashBytes([]byte("test")).Hex()
 	assert.Equal(t, "0x9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658", h)
 
-	h = HashBytes([]byte("authorizeksign")).Hex()
+	h = hashBytes([]byte("authorizeksign")).Hex()
 	assert.Equal(t, "0x353f867ef725411de05e3d4b0a01c37cf7ad24bcc213141a05ed7726d7932a1f", h)
 }

--- a/services/backupsrv/service.go
+++ b/services/backupsrv/service.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/fatih/color"
 	common3 "github.com/iden3/go-iden3/common"
-	"github.com/iden3/go-iden3/merkletree"
 	"github.com/iden3/go-iden3/services/claimsrv"
 	"github.com/iden3/go-iden3/services/mongosrv"
 	"github.com/iden3/go-iden3/utils"
@@ -54,7 +53,7 @@ func (bs *ServiceImpl) Save(idaddr common.Address, m BackupData) (uint64, error)
 	if err != nil {
 		return 0, err
 	}
-	hash := merkletree.HashBytes(b)
+	hash := utils.HashBytes(b)
 	if !utils.CheckPoW(hash, bs.GetPoWDifficulty()) {
 		return 0, errors.New("PoW not passed")
 	}

--- a/services/backupsrv/service_test.go
+++ b/services/backupsrv/service_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/iden3/go-iden3/merkletree"
 	"github.com/iden3/go-iden3/utils"
 	"github.com/stretchr/testify/assert"
 )
@@ -54,6 +53,6 @@ func TestPoWBackupData(t *testing.T) {
 	assert.Nil(t, err)
 	b, err := json.Marshal(data)
 	assert.Nil(t, err)
-	hash := merkletree.HashBytes(b)
+	hash := utils.HashBytes(b)
 	assert.True(t, utils.CheckPoW(hash, 2))
 }

--- a/services/namesrv/messages.go
+++ b/services/namesrv/messages.go
@@ -2,7 +2,6 @@ package namesrv
 
 import (
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/iden3/go-iden3/merkletree"
 	"github.com/iden3/go-iden3/utils"
 )
 
@@ -25,7 +24,7 @@ type VinculateIDMsg struct {
 }
 
 // MsgHash returns the Hash(VinculateIDMsg)
-func (m *VinculateIDMsg) MsgHash() merkletree.Hash {
+func (m *VinculateIDMsg) MsgHash() utils.Hash {
 	var b []byte
 	b = append(b, m.EthID.Bytes()...)
 	b = append(b, []byte(m.Name)...)

--- a/services/namesrv/service.go
+++ b/services/namesrv/service.go
@@ -54,8 +54,8 @@ func (ns *ServiceImpl) VinculateID(vinculateIDMsg VinculateIDMsg) (core.AssignNa
 	}
 
 	// add AssignNameClaim to merkle tree
-	nameHash := merkletree.HashBytes([]byte(vinculateIDMsg.Name))
-	domainHash := merkletree.HashBytes([]byte(ns.domain))
+	nameHash := utils.HashBytes([]byte(vinculateIDMsg.Name))
+	domainHash := utils.HashBytes([]byte(ns.domain))
 	assignNameClaim := core.NewAssignNameClaim(nameHash, domainHash, vinculateIDMsg.EthID)
 	err = ns.claimsrv.AddAssignNameClaim(assignNameClaim)
 	if err != nil {
@@ -76,8 +76,8 @@ func (ns *ServiceImpl) ResolvAssignNameClaim(nameid string) (core.AssignNameClai
 	domain := s[1]
 
 	// build the AssignNameClaim Partial with the given data of the Index
-	nameHash := merkletree.HashBytes([]byte(name))
-	domainHash := merkletree.HashBytes([]byte(domain))
+	nameHash := utils.HashBytes([]byte(name))
+	domainHash := utils.HashBytes([]byte(domain))
 	claimPartial := core.NewAssignNameClaim(nameHash, domainHash, common.Address{})
 
 	version, err := claimsrv.GetNextVersion(ns.claimsrv.MT(), claimPartial.Hi())

--- a/utils/hash.go
+++ b/utils/hash.go
@@ -1,0 +1,29 @@
+package utils
+
+import (
+	"encoding/hex"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// Hash used in this tree, is the [32]byte keccak()
+type Hash [32]byte
+
+// hashBytes performs a Keccak256 hash over the bytes
+func HashBytes(b []byte) (hash Hash) {
+	h := crypto.Keccak256(b)
+	copy(hash[:], h)
+	return hash
+}
+
+// Bytes returns a byte array from a Hash
+func (hash Hash) Bytes() []byte {
+	return hash[:]
+}
+
+// Hex returns a hex string from the Hash type
+func (hash Hash) Hex() string {
+	r := "0x"
+	h := hex.EncodeToString(hash[:])
+	r = r + h
+	return r
+}

--- a/utils/hash_test.go
+++ b/utils/hash_test.go
@@ -1,0 +1,14 @@
+package utils
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestHashBytes(t *testing.T) {
+	h := HashBytes([]byte("test")).Hex()
+	assert.Equal(t, "0x9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658", h)
+
+	h = HashBytes([]byte("authorizeksign")).Hex()
+	assert.Equal(t, "0x353f867ef725411de05e3d4b0a01c37cf7ad24bcc213141a05ed7726d7932a1f", h)
+}

--- a/utils/signatures.go
+++ b/utils/signatures.go
@@ -9,17 +9,16 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/iden3/go-iden3/merkletree"
 )
 
 // Sign performs the signature over a Hash
-func Sign(h merkletree.Hash, ks *keystore.KeyStore, acc accounts.Account) ([]byte, error) {
+func Sign(h Hash, ks *keystore.KeyStore, acc accounts.Account) ([]byte, error) {
 	return ks.SignHash(acc, h[:])
 }
 
-func EthHash(b []byte) merkletree.Hash {
+func EthHash(b []byte) Hash {
 	msg := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", len(b), b)
-	return merkletree.HashBytes([]byte(msg))
+	return HashBytes([]byte(msg))
 }
 
 // VerifySig verifies a given signature and the msgHash with the expected address

--- a/utils/signatures_test.go
+++ b/utils/signatures_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/crypto"
 	common3 "github.com/iden3/go-iden3/common"
-	"github.com/iden3/go-iden3/merkletree"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,7 +32,7 @@ func TestVerifySig(t *testing.T) {
 	assert.Nil(t, err)
 	testPrivK, err := crypto.HexToECDSA(testPrivKHex)
 	assert.Nil(t, err)
-	msgHash := merkletree.HashBytes([]byte("to sign"))
+	msgHash := HashBytes([]byte("to sign"))
 	testAddr := crypto.PubkeyToAddress(testPrivK.PublicKey)
 	assert.True(t, VerifySig(testAddr, signature, msgHash[:]))
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"time"
-
-	"github.com/iden3/go-iden3/merkletree"
 )
 
 // PoWData is the interface for the data that have the Nonce parameter to calculate the Proof-of-Work
@@ -13,8 +11,8 @@ type PoWData interface {
 	IncrementNonce() PoWData
 }
 
-// CheckPoW verifies the PoW difficulty of a merkletree.Hash
-func CheckPoW(hash merkletree.Hash, difficulty int) bool {
+// CheckPoW verifies the PoW difficulty of a Hash
+func CheckPoW(hash Hash, difficulty int) bool {
 	var empty [32]byte
 	if !bytes.Equal(hash.Bytes()[0:difficulty], empty[0:difficulty]) {
 		return false
@@ -28,7 +26,7 @@ func PoW(data PoWData, difficulty int) (PoWData, error) {
 	if err != nil {
 		return nil, err
 	}
-	hash := merkletree.HashBytes(b)
+	hash := HashBytes(b)
 	for !CheckPoW(hash, difficulty) {
 		data = data.IncrementNonce()
 
@@ -36,7 +34,7 @@ func PoW(data PoWData, difficulty int) (PoWData, error) {
 		if err != nil {
 			return nil, err
 		}
-		hash = merkletree.HashBytes(b)
+		hash = HashBytes(b)
 	}
 	return data, nil
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/iden3/go-iden3/merkletree"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -27,7 +26,7 @@ func TestPoW(t *testing.T) {
 	assert.Nil(t, err)
 	b, err := json.Marshal(data)
 	assert.Nil(t, err)
-	hash := merkletree.HashBytes(b)
+	hash := HashBytes(b)
 	assert.True(t, CheckPoW(hash, 2))
 	assert.True(t, !CheckPoW(hash, 3))
 
@@ -41,7 +40,7 @@ func TestCheckPoW(t *testing.T) {
 	}
 	b, err := json.Marshal(testData)
 	assert.Nil(t, err)
-	hash := merkletree.HashBytes(b)
+	hash := HashBytes(b)
 	assert.True(t, CheckPoW(hash, 2))
 	assert.True(t, !CheckPoW(hash, 3))
 


### PR DESCRIPTION
Solves issue #42 

I have added a placeholder HashBytes function in the merkletree module as a temporary function to ease us transition to the new claims specification.