### PR TITLE
Implement new spec for claims

### DIFF
--- a/core/claim_test.go
+++ b/core/claim_test.go
@@ -1,179 +1,142 @@
 package core
 
 import (
-	"bytes"
-	"encoding/hex"
+	//"bytes"
+	//"encoding/hex"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	common3 "github.com/iden3/go-iden3/common"
-	"github.com/iden3/go-iden3/db"
+	//common3 "github.com/iden3/go-iden3/common"
+	//"github.com/iden3/go-iden3/db"
 	"github.com/iden3/go-iden3/merkletree"
-	"github.com/iden3/go-iden3/utils"
+	//"github.com/iden3/go-iden3/utils"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseTypeClaimBytes(t *testing.T) {
-	// default claim
-	claimHex := "0x3cfc3a1edbf691316fec9b75970fbfb2b0e8d8edfc6ec7628db77c4969403074cfee7c08a98f4b565d124c7e4e28acc52e1bc780e3887db000000040000000006331"
-	claimBytes, err := common3.HexToBytes(claimHex)
+func TestClaimBasic(t *testing.T) {
+	// ClaimBasic
+	indexSlot := [400 / 8]byte{42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42}
+	dataSlot := [496 / 8]byte{88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88}
+	c0 := NewClaimBasic(indexSlot, dataSlot)
+	e := c0.ToEntry()
+	assert.Equal(t, e.Data.String(),
+		"00585858585858585858585858585858585858585858585858585858585858580058585858585858585858585858585858585858585858585858585858585858002a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a002a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a0000000080db04d364e4c1aa")
+	c1 := NewClaimBasicFromEntry(&e)
+	c2, err := NewClaimFromEntry(&e)
 	assert.Nil(t, err)
-	claimType, err := ParseTypeClaimBytes(claimBytes)
-	assert.Nil(t, err)
-	assert.Equal(t, "default", claimType)
-
-	// assignNameClaim type
-	claimHex = "0x3cfc3a1edbf691316fec9b75970fbfb2b0e8d8edfc6ec7628db77c4969403074b7ae3d3a2056c54f48763999f3ff99caffaaba3bab58cae900000080000000009c4b7a6b4af91b44be8d9bb66d41e82589f01974702d3bf1d9b4407a55593c3c3cfc3a1edbf691316fec9b75970fbfb2b0e8d8edfc6ec7628db77c4969403074101d2fa51f8259df207115af9eaa73f3f4e52e60"
-	claimBytes, err = common3.HexToBytes(claimHex)
-	assert.Nil(t, err)
-	claimType, err = ParseTypeClaimBytes(claimBytes)
-	assert.Nil(t, err)
-	assert.Equal(t, "assignname", claimType)
-
-	// authorizeKSignClaim type
-	claimHex = "0x3cfc3a1edbf691316fec9b75970fbfb2b0e8d8edfc6ec7628db77c4969403074353f867ef725411de05e3d4b0a01c37cf7ad24bcc213141a0000005400000000101d2fa51f8259df207115af9eaa73f3f4e52e602077bb3f0400dd62421c97220536fd6ed2be29228e8db1315e8c6d7525f4bdf4dad9966a2e7371f0a24b1929ed765c0e7a3f2b4665a76a19d58173308bb34062000000005b816b9e000000005b816b9e"
-	claimBytes, err = common3.HexToBytes(claimHex)
-	assert.Nil(t, err)
-	claimType, err = ParseTypeClaimBytes(claimBytes)
-	assert.Nil(t, err)
-	assert.Equal(t, "authorizeksign", claimType)
-
-	// setRootClaim type
-	claimHex = "0x3cfc3a1edbf691316fec9b75970fbfb2b0e8d8edfc6ec7628db77c49694030749b9a76a0132a0814192c05c9321efc30c7286f6187f18fc60000005400000000101d2fa51f8259df207115af9eaa73f3f4e52e607d2e30055477edf346d81dac92720729aed3ef830cf26b012b38f2f8304ac18c"
-	claimBytes, err = common3.HexToBytes(claimHex)
-	assert.Nil(t, err)
-	claimType, err = ParseTypeClaimBytes(claimBytes)
-	assert.Nil(t, err)
-	assert.Equal(t, "setroot", claimType)
-}
-func TestClaimGenerationAndParse(t *testing.T) {
-	claim := NewGenericClaim("iden3.io", "default", []byte("c1"), []byte{})
-	assert.Equal(t, "0x3cfc3a1edbf691316fec9b75970fbfb2b0e8d8edfc6ec7628db77c4969403074cfee7c08a98f4b565d124c7e4e28acc52e1bc780e3887db000000042000000006331", common3.BytesToHex(claim.Bytes()))
-
-	claimHt := claim.Ht()
-	assert.Equal(t, "0x0fce11cbd33e15d137a3a1953cda71aa81898ee8b917c21615073b59cd4dca8c", common3.BytesToHex(claimHt[:]))
-
-	claimParsed, err := ParseGenericClaimBytes(claim.Bytes())
-	assert.Nil(t, err)
-	if !bytes.Equal(claim.Bytes(), claimParsed.Bytes()) {
-		t.Errorf("claim and claimParsed not equal")
-	}
+	assert.Equal(t, c0, c1)
+	assert.Equal(t, &c0, c2)
 }
 
-func TestAssignNameClaim(t *testing.T) {
-	assignNameClaim := NewAssignNameClaim(utils.HashBytes([]byte("john")), utils.HashBytes([]byte("iden3.io")), common.HexToAddress("0x101d2fa51f8259df207115af9eaa73f3f4e52e60"))
-	assignNameClaimParsed, err := ParseAssignNameClaimBytes(assignNameClaim.Bytes())
+func TestClaimAssignName(t *testing.T) {
+	// ClaimAssignName
+	name := "example.iden3.eth"
+	ethID := common.BytesToAddress([]byte{71, 71, 71, 71, 71, 71, 71, 71, 71, 71, 71, 71, 71, 71, 71, 71, 71, 71, 71, 71})
+	c0 := NewClaimAssignName(name, ethID)
+	e := c0.ToEntry()
+	assert.Equal(t, e.Data.String(),
+		"0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000474747474747474747474747474747474747474700805add1af17a3ee26b3c8c5751a19d2edd51844be8f3e8acd1e2d8057bd6480000000000000000000000000000000000000000000000005fd72e7912afa9ff")
+	c1 := NewClaimAssignNameFromEntry(&e)
+	c2, err := NewClaimFromEntry(&e)
 	assert.Nil(t, err)
-	if !bytes.Equal(assignNameClaimParsed.Bytes(), assignNameClaim.Bytes()) {
-		t.Errorf("assignNameClaim and assignNameClaim parsed are not equals")
-	}
-	assert.Equal(t, "0x3cfc3a1edbf691316fec9b75970fbfb2b0e8d8edfc6ec7628db77c4969403074b7ae3d3a2056c54f48763999f3ff99caffaaba3bab58cae900000080000000009c4b7a6b4af91b44be8d9bb66d41e82589f01974702d3bf1d9b4407a55593c3c3cfc3a1edbf691316fec9b75970fbfb2b0e8d8edfc6ec7628db77c4969403074101d2fa51f8259df207115af9eaa73f3f4e52e60", common3.BytesToHex(assignNameClaim.Bytes()))
-
-	assert.Equal(t, "0xfa7c93d75fc4b617a8ab43afd1def1a06ffc0c227ce25edc93b235e4df084cf0", assignNameClaim.Hi().Hex())
-	assert.Equal(t, "0xa09dafa7ebe716f4c35a316c4c332d47b2bb3c101402f9ba4467ed676719d45a", assignNameClaim.Ht().Hex())
+	assert.Equal(t, c0, c1)
+	assert.Equal(t, &c0, c2)
 }
 
-func TestAuthorizeKSign(t *testing.T) {
-	authorizeKSignClaim := NewAuthorizeKSignClaim(common.HexToAddress("0x101d2fa51f8259df207115af9eaa73f3f4e52e60"), "appToAuthName", "authz", 1535208350, 1535208350)
-	authorizeKSignClaimParsed, err := ParseAuthorizeKSignClaimBytes(authorizeKSignClaim.Bytes())
+func TestClaimAuthorizeKSign(t *testing.T) {
+	// ClaimAuthorizeKSign
+	sign := true
+	ax := [128 / 8]byte{25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25}
+	ay := [128 / 8]byte{77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77}
+	c0 := NewClaimAuthorizeKSign(sign, ax, ay)
+	e := c0.ToEntry()
+	assert.Equal(t, e.Data.String(),
+		"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d000000191919191919191919191919191919190100000000e75c97ad68ba5cc8")
+	c1 := NewClaimAuthorizeKSignFromEntry(&e)
+	c2, err := NewClaimFromEntry(&e)
 	assert.Nil(t, err)
-	if !bytes.Equal(authorizeKSignClaimParsed.Bytes(), authorizeKSignClaim.Bytes()) {
-		t.Errorf("ksignClaim and ksignClaim parsed are not equals")
-	}
-	assert.Equal(t, "0x3cfc3a1edbf691316fec9b75970fbfb2b0e8d8edfc6ec7628db77c4969403074353f867ef725411de05e3d4b0a01c37cf7ad24bcc213141a0000005400000000101d2fa51f8259df207115af9eaa73f3f4e52e602077bb3f0400dd62421c97220536fd6ed2be29228e8db1315e8c6d7525f4bdf4dad9966a2e7371f0a24b1929ed765c0e7a3f2b4665a76a19d58173308bb34062000000005b816b9e000000005b816b9e", common3.BytesToHex(authorizeKSignClaim.Bytes()))
-	assert.Equal(t, "0xb98902d35fe0861daaeb78ada21e60e1d7c009b6e56d85127e892aeb4ed37ef2", authorizeKSignClaim.Hi().Hex())
-	assert.Equal(t, "0x9a1d4978ced5adfd4c4de9ee1bb4f850e0db426855737a5ecf0749d150620422", authorizeKSignClaim.Ht().Hex())
-
-}
-func TestSetRootClaim(t *testing.T) {
-	setRootClaim := NewSetRootClaim(common.HexToAddress("0x101d2fa51f8259df207115af9eaa73f3f4e52e60"), merkletree.HashBytes([]byte("root of the MT")))
-	setRootClaimParsed, err := ParseSetRootClaimBytes(setRootClaim.Bytes())
-	assert.Nil(t, err)
-	if !bytes.Equal(setRootClaimParsed.Bytes(), setRootClaim.Bytes()) {
-		t.Errorf("setRootClaim and setRootClaim parsed are not equals")
-	}
-	assert.Equal(t, "0x3cfc3a1edbf691316fec9b75970fbfb2b0e8d8edfc6ec7628db77c49694030749b9a76a0132a0814192c05c9321efc30c7286f6187f18fc60000005400000000101d2fa51f8259df207115af9eaa73f3f4e52e607d2e30055477edf346d81dac92720729aed3ef830cf26b012b38f2f8304ac18c", common3.BytesToHex(setRootClaim.Bytes()))
-
-	assert.Equal(t, "0x7e76f2faee2b80b1d794271fe06b6fa52b06bcabc48441473ae28aa281b19965", setRootClaim.Hi().Hex())
-	assert.Equal(t, "0xaf49c9214bb28b886e197df5b5e38c0ea54b3334039f419375e0fb4d1f70e44c", setRootClaim.Ht().Hex())
+	assert.Equal(t, c0, c1)
+	assert.Equal(t, &c0, c2)
 }
 
-func TestForwardingInterop(t *testing.T) {
-
-	// address 0xee602447b5a75cf4f25367f5d199b860844d10c4
-	// pvk     8A85AAA2A8CE0D24F66D3EAA7F9F501F34992BACA0FF942A8EDF7ECE6B91F713
-
-	mt, err := merkletree.New(db.NewMemoryStorage(), 140)
+func TestClaimSetRootKey(t *testing.T) {
+	// ClaimSetRootKey
+	ethID := common.BytesToAddress([]byte{57, 57, 57, 57, 57, 57, 57, 57, 57, 57, 57, 57, 57, 57, 57, 57})
+	rootKey := merkletree.Hash(merkletree.ElemBytes{00, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11})
+	c0 := NewClaimSetRootKey(ethID, rootKey)
+	e := c0.ToEntry()
+	assert.Equal(t, e.Data.String(),
+		"0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000b0b0b0b0b0b0b0b0b0b0b0b0b0b0b000000000000000000000000003939393939393939393939393939393900000000000000000000000000000000000000000000000000000000e400a1345fb8a750")
+	c1 := NewClaimSetRootKeyFromEntry(&e)
+	c2, err := NewClaimFromEntry(&e)
 	assert.Nil(t, err)
-
-	// create ksignclaim ----------------------------------------------
-
-	ksignClaim := NewOperationalKSignClaim(common.HexToAddress("0xee602447b5a75cf4f25367f5d199b860844d10c4"))
-
-	assert.Nil(t, mt.Add(ksignClaim))
-
-	kroot := mt.Root()
-	kproof, err := mt.GenerateProof(ksignClaim.Hi())
-	assert.Nil(t, err)
-	assert.True(t, merkletree.CheckProof(kroot, kproof, ksignClaim.Hi(), ksignClaim.Ht(), 140))
-
-	assert.Equal(t, "0x3cfc3a1edbf691316fec9b75970fbfb2b0e8d8edfc6ec7628db77c4969403074353f867ef725411de05e3d4b0a01c37cf7ad24bcc213141a0000005400000000ee602447b5a75cf4f25367f5d199b860844d10c4000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffff", common3.BytesToHex(ksignClaim.Bytes()))
-	assert.Equal(t, uint32(84), ksignClaim.BaseIndex.IndexLength)
-	assert.Equal(t, 84, int(ksignClaim.IndexLength()))
-	assert.Equal(t, "0x68be938284f64944bd8ebc172792687f680fb8db13e383227c8c668820b40078", ksignClaim.Hi().Hex())
-	assert.Equal(t, "0xdd675b18734a480868ed7b258ec2306a8e676690a81d53bcda7490c31368edd2", ksignClaim.Ht().Hex())
-	assert.Equal(t, "0x93bf43768a1e034e583832a9ee992c37374047be910aa1e80258fc2f27d46628", kroot.Hex())
-	assert.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000000", common3.BytesToHex(kproof))
-
-	ksignClaim.BaseIndex.Version = 1
-	kproofneg, err := mt.GenerateProof(ksignClaim.Hi())
-	assert.Nil(t, err)
-	assert.Equal(t, "0xeab0608b8891dcca4f421c69244b17f208fbed899b540d01115ca7d907cbf6a5", ksignClaim.Hi().Hex())
-	assert.True(t, merkletree.CheckProof(kroot, kproofneg, ksignClaim.Hi(), merkletree.EmptyNodeValue, 140))
-	assert.Equal(t, "0x000000000000000000000000000000000000000000000000000000000000000103aab4f597fe23598cc10f1af68192195a7538d3d6fc83cf49e5cfd53eaac527", common3.BytesToHex(kproofneg))
-
-	// create setrootclaim ----------------------------------------------
-
-	mt, err = merkletree.New(db.NewMemoryStorage(), 140)
-	assert.Nil(t, err)
-
-	setRootClaim := NewSetRootClaim(
-		common.HexToAddress("0xd79ae0a65e7dd29db1eac700368e693de09610b8"),
-		kroot,
-	)
-
-	assert.Nil(t, mt.Add(setRootClaim))
-
-	rroot := mt.Root()
-	rproof, err := mt.GenerateProof(setRootClaim.Hi())
-	assert.Nil(t, err)
-
-	assert.True(t, merkletree.CheckProof(rroot, rproof, setRootClaim.Hi(), setRootClaim.Ht(), 140))
-	assert.Equal(t, uint32(84), setRootClaim.BaseIndex.IndexLength)
-	assert.Equal(t, 84, int(setRootClaim.IndexLength()))
-	assert.Equal(t, "0x3cfc3a1edbf691316fec9b75970fbfb2b0e8d8edfc6ec7628db77c49694030749b9a76a0132a0814192c05c9321efc30c7286f6187f18fc60000005400000000d79ae0a65e7dd29db1eac700368e693de09610b893bf43768a1e034e583832a9ee992c37374047be910aa1e80258fc2f27d46628", common3.BytesToHex(setRootClaim.Bytes()))
-	assert.Equal(t, "0x497d8626567f90e3e14de025961133ca7e4959a686c75a062d4d4db750d607b0", setRootClaim.Hi().Hex())
-	assert.Equal(t, "0x6da033d96fdde2c687a48a4902823f9f8e91b31e3d73c57f3858e8a9650f9c39", setRootClaim.Ht().Hex())
-	assert.Equal(t, "0xab63a4a3c5fe879e1b55315b945ac7f1ac1ac4b059e7301964b99b6813b514c7", rroot.Hex())
-	assert.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000000", common3.BytesToHex(rproof))
-
-	setRootClaim.BaseIndex.Version++
-	rproofneg, err := mt.GenerateProof(setRootClaim.Hi())
-	assert.Nil(t, err)
-	assert.True(t, merkletree.CheckProof(rroot, rproofneg, setRootClaim.Hi(), merkletree.EmptyNodeValue, 140))
-	assert.Equal(t, "0x00000000000000000000000000000000000000000000000000000000000000016f33cf71ff7bdbc492f9c3bd63b15577e6cedc70afd09051e1dfe2f04340c073", common3.BytesToHex(rproofneg))
+	assert.Equal(t, c0, c1)
+	assert.Equal(t, &c0, c2)
 }
 
-// hexToBytes converts from a hex string into an array of bytes
-func hexToHash(hexstr string) merkletree.Hash {
-	var h merkletree.Hash
-	b, err := hex.DecodeString(hexstr[2:])
-	if err != nil {
-		panic(err)
-	}
-	if len(b) != len(h) {
-		panic("Invalid hash length")
-	}
-	copy(h[:], b[:])
-	return h
-}
+// TODO: Update to new claim spec.
+//func TestForwardingInterop(t *testing.T) {
+//
+//	// address 0xee602447b5a75cf4f25367f5d199b860844d10c4
+//	// pvk     8A85AAA2A8CE0D24F66D3EAA7F9F501F34992BACA0FF942A8EDF7ECE6B91F713
+//
+//	mt, err := merkletree.New(db.NewMemoryStorage(), 140)
+//	assert.Nil(t, err)
+//
+//	// create ksignclaim ----------------------------------------------
+//
+//	ksignClaim := NewOperationalKSignClaim(common.HexToAddress("0xee602447b5a75cf4f25367f5d199b860844d10c4"))
+//
+//	assert.Nil(t, mt.Add(ksignClaim))
+//
+//	kroot := mt.Root()
+//	kproof, err := mt.GenerateProof(ksignClaim.Hi())
+//	assert.Nil(t, err)
+//	assert.True(t, merkletree.CheckProof(kroot, kproof, ksignClaim.Hi(), ksignClaim.Ht(), 140))
+//
+//	assert.Equal(t, "0x3cfc3a1edbf691316fec9b75970fbfb2b0e8d8edfc6ec7628db77c4969403074353f867ef725411de05e3d4b0a01c37cf7ad24bcc213141a0000005400000000ee602447b5a75cf4f25367f5d199b860844d10c4000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffff", common3.BytesToHex(ksignClaim.Bytes()))
+//	assert.Equal(t, uint32(84), ksignClaim.BaseIndex.IndexLength)
+//	assert.Equal(t, 84, int(ksignClaim.IndexLength()))
+//	assert.Equal(t, "0x68be938284f64944bd8ebc172792687f680fb8db13e383227c8c668820b40078", ksignClaim.Hi().Hex())
+//	assert.Equal(t, "0xdd675b18734a480868ed7b258ec2306a8e676690a81d53bcda7490c31368edd2", ksignClaim.Ht().Hex())
+//	assert.Equal(t, "0x93bf43768a1e034e583832a9ee992c37374047be910aa1e80258fc2f27d46628", kroot.Hex())
+//	assert.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000000", common3.BytesToHex(kproof))
+//
+//	ksignClaim.BaseIndex.Version = 1
+//	kproofneg, err := mt.GenerateProof(ksignClaim.Hi())
+//	assert.Nil(t, err)
+//	assert.Equal(t, "0xeab0608b8891dcca4f421c69244b17f208fbed899b540d01115ca7d907cbf6a5", ksignClaim.Hi().Hex())
+//	assert.True(t, merkletree.CheckProof(kroot, kproofneg, ksignClaim.Hi(), merkletree.EmptyNodeValue, 140))
+//	assert.Equal(t, "0x000000000000000000000000000000000000000000000000000000000000000103aab4f597fe23598cc10f1af68192195a7538d3d6fc83cf49e5cfd53eaac527", common3.BytesToHex(kproofneg))
+//
+//	// create setrootclaim ----------------------------------------------
+//
+//	mt, err = merkletree.New(db.NewMemoryStorage(), 140)
+//	assert.Nil(t, err)
+//
+//	setRootClaim := NewSetRootClaim(
+//		common.HexToAddress("0xd79ae0a65e7dd29db1eac700368e693de09610b8"),
+//		kroot,
+//	)
+//
+//	assert.Nil(t, mt.Add(setRootClaim))
+//
+//	rroot := mt.Root()
+//	rproof, err := mt.GenerateProof(setRootClaim.Hi())
+//	assert.Nil(t, err)
+//
+//	assert.True(t, merkletree.CheckProof(rroot, rproof, setRootClaim.Hi(), setRootClaim.Ht(), 140))
+//	assert.Equal(t, uint32(84), setRootClaim.BaseIndex.IndexLength)
+//	assert.Equal(t, 84, int(setRootClaim.IndexLength()))
+//	assert.Equal(t, "0x3cfc3a1edbf691316fec9b75970fbfb2b0e8d8edfc6ec7628db77c49694030749b9a76a0132a0814192c05c9321efc30c7286f6187f18fc60000005400000000d79ae0a65e7dd29db1eac700368e693de09610b893bf43768a1e034e583832a9ee992c37374047be910aa1e80258fc2f27d46628", common3.BytesToHex(setRootClaim.Bytes()))
+//	assert.Equal(t, "0x497d8626567f90e3e14de025961133ca7e4959a686c75a062d4d4db750d607b0", setRootClaim.Hi().Hex())
+//	assert.Equal(t, "0x6da033d96fdde2c687a48a4902823f9f8e91b31e3d73c57f3858e8a9650f9c39", setRootClaim.Ht().Hex())
+//	assert.Equal(t, "0xab63a4a3c5fe879e1b55315b945ac7f1ac1ac4b059e7301964b99b6813b514c7", rroot.Hex())
+//	assert.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000000", common3.BytesToHex(rproof))
+//
+//	setRootClaim.BaseIndex.Version++
+//	rproofneg, err := mt.GenerateProof(setRootClaim.Hi())
+//	assert.Nil(t, err)
+//	assert.True(t, merkletree.CheckProof(rroot, rproofneg, setRootClaim.Hi(), merkletree.EmptyNodeValue, 140))
+//	assert.Equal(t, "0x00000000000000000000000000000000000000000000000000000000000000016f33cf71ff7bdbc492f9c3bd63b15577e6cedc70afd09051e1dfe2f04340c073", common3.BytesToHex(rproofneg))
+//}

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/ipfs/go-ipfs-api v1.3.5
 	github.com/ipfs/go-ipfs-cmdkit v1.1.3 // indirect
 	github.com/ipfsconsortium/go-ipfsc v0.0.0-20180821102820-2014c66a1b4a
+	github.com/koron/iferr v0.0.0-20180615142939-bb332a3b1d91 // indirect
 	github.com/libp2p/go-flow-metrics v0.2.0 // indirect
 	github.com/libp2p/go-libp2p-crypto v2.0.1+incompatible // indirect
 	github.com/libp2p/go-libp2p-metrics v2.1.7+incompatible // indirect
@@ -45,6 +46,7 @@ require (
 	github.com/sirupsen/logrus v1.1.0
 	github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 // indirect
 	github.com/spf13/viper v1.2.1
+	github.com/stamblerre/gocode v0.0.0-20181212030458-2f9d39d8f31d // indirect
 	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/stretchr/testify v1.2.2
 	github.com/syndtr/goleveldb v0.0.0-20180815032940-ae2bd5eed72d
@@ -53,6 +55,7 @@ require (
 	github.com/whyrusleeping/tar-utils v0.0.0-20180509141711-8c6c8ba81d5c // indirect
 	golang.org/x/crypto v0.0.0-20180904163835-0709b304e793
 	golang.org/x/net v0.0.0-20180926154720-4dfa2610cdf3 // indirect
+	golang.org/x/tools v0.0.0-20181221235234-d00ac6d27372 // indirect
 	gopkg.in/go-playground/validator.v8 v8.18.2 // indirect
 	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce
 )

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/ipfs/go-ipfs-cmdkit v1.1.3/go.mod h1:9FtbMdUabcSqv/G4/8WCxSLxkZxn/aZE
 github.com/ipfsconsortium/go-ipfsc v0.0.0-20180821102820-2014c66a1b4a h1:VtDdZ/bCn1ixR+7k5AodUZIOUsaBI7Gmpi9B7hMqVnk=
 github.com/ipfsconsortium/go-ipfsc v0.0.0-20180821102820-2014c66a1b4a/go.mod h1:4MbfcV8YX3CWjkWgUIH4vEVk002kMJlOEmhoSJP8SeE=
 github.com/konsorten/go-windows-terminal-sequences v0.0.0-20180402223658-b729f2633dfe/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/koron/iferr v0.0.0-20180615142939-bb332a3b1d91 h1:hunjgdb3b21ZdRmzDPXii0EcnHpjH7uCP+kODoE1JH0=
+github.com/koron/iferr v0.0.0-20180615142939-bb332a3b1d91/go.mod h1:C2tFh8w3I6i4lnUJfoBx2Hwku3mgu4wPNTtUNp1i5KI=
 github.com/libp2p/go-flow-metrics v0.2.0 h1:GAJSg/g+xLuc7vz0RN96pRA9q/n5b5+Hs6SndagmOR4=
 github.com/libp2p/go-flow-metrics v0.2.0/go.mod h1:Iv1GH0sG8DtYN3SVJ2eG221wMiNpZxBdp967ls1g+k8=
 github.com/libp2p/go-libp2p-crypto v2.0.1+incompatible h1:JAnZYupeAsZI5UqX50N9MWAVNO5HIfkow249YcmuvVs=
@@ -118,6 +120,8 @@ github.com/spf13/pflag v1.0.2 h1:Fy0orTDgHdbnzHcsOgfCN4LtHf0ec3wwtiwJqwvf3Gc=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v1.2.1 h1:bIcUwXqLseLF3BDAZduuNfekWG87ibtFxi59Bq+oI9M=
 github.com/spf13/viper v1.2.1/go.mod h1:P4AexN0a+C9tGAnUFNwDMYYZv3pjFuvmeiMyKRaNVlI=
+github.com/stamblerre/gocode v0.0.0-20181212030458-2f9d39d8f31d h1:Bpu5DolLksGPpggDvoP5l9aruCElc6a47pHOSWwL74A=
+github.com/stamblerre/gocode v0.0.0-20181212030458-2f9d39d8f31d/go.mod h1:EM2T8YDoTCvGXbEpFHxarbpv7VE26QD1++Cb1Pbh7Gs=
 github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
@@ -144,6 +148,8 @@ golang.org/x/sys v0.0.0-20180926160741-c2ed4eda69e7 h1:bit1t3mgdR35yN0cX0G8orgLt
 golang.org/x/sys v0.0.0-20180926160741-c2ed4eda69e7/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20181221235234-d00ac6d27372 h1:zWPUEY/PjVHT+zO3L8OfkjrtIjf55joTxn/RQP/AjOI=
+golang.org/x/tools v0.0.0-20181221235234-d00ac6d27372/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=

--- a/merkletree/merkletree.go
+++ b/merkletree/merkletree.go
@@ -42,9 +42,14 @@ func ElemsBytesToBytes(es []ElemBytes) []byte {
 type Index [IndexLen]ElemBytes
 
 // Data is the type used to represent the data stored in an entry of the MT.
-// It consists of 4 elements: e1, e2, e3, e4;
-// where v = [e1,e2], index = [e3,e4].
+// It consists of 4 elements: e0, e1, e2, e3;
+// where v = [e0,e1], index = [e2,e3].
 type Data [DataLen]ElemBytes
+
+func (d *Data) String() string {
+	return fmt.Sprintf("%s%s%s%s", hex.EncodeToString(d[0][:]), hex.EncodeToString(d[1][:]),
+		hex.EncodeToString(d[2][:]), hex.EncodeToString(d[3][:]))
+}
 
 const (
 	// ElemBytesLen is the length in bytes of each element used for storing
@@ -83,6 +88,10 @@ type Entry struct {
 	Data   Data
 	hIndex *Hash
 	hTotal *Hash
+}
+
+type Entrier interface {
+	ToEntry() Entry
 }
 
 // HIndex calculates the hash of the Index of the entry, used to find the path


### PR DESCRIPTION
Merkle tree entries were modified from variable length byte arrays to using 4
Elements.  This commit updates the claims to make them smaller to fit into 4
Elements.

Resolve #40 