### PR TITLE
Fix merkletree and claim new versions to compile again and pass the t…

### DIFF
--- a/cmd/relay/commands/claim.go
+++ b/cmd/relay/commands/claim.go
@@ -53,8 +53,13 @@ func cmdAddClaim(c *cli.Context) error {
 
 	var indexSlot [400 / 8]byte
 	var dataSlot [496 / 8]byte
-	copy(indexSlot[:], indexData[:400/8])
-	copy(dataSlot[:], outData[:496/8])
+	if len(indexData) != len(indexSlot) || len(outData) != len(dataSlot) {
+		return fmt.Errorf(
+			"Length of indexSlot and dataSlot must be %v and %v respectively",
+			len(indexSlot), len(dataSlot))
+	}
+	copy(indexSlot[:], indexData)
+	copy(dataSlot[:], outData)
 	claim := core.NewClaimBasic(indexSlot, dataSlot)
 	fmt.Println("clam: " + common3.BytesToHex(claim.Entry().Bytes()))
 
@@ -104,8 +109,13 @@ func cmdAddClaimsFromFile(c *cli.Context) error {
 
 		var indexSlot [400 / 8]byte
 		var dataSlot [496 / 8]byte
-		copy(indexSlot[:], line[0][:400/8])
-		copy(dataSlot[:], line[1][:496/8])
+		if len(line[0]) != len(indexSlot) || len(line[1]) != len(dataSlot) {
+			return fmt.Errorf(
+				"Length of indexSlot and dataSlot must be %v and %v respectively",
+				len(indexSlot), len(dataSlot))
+		}
+		copy(indexSlot[:], line[0])
+		copy(dataSlot[:], line[1])
 		claim := core.NewClaimBasic(indexSlot, dataSlot)
 		// claim := core.NewGenericClaim("iden3.io", "generic", []byte(line[0]), []byte(line[1]))
 		fmt.Println("clam: " + common3.BytesToHex(claim.Entry().Bytes()) + "\n")
@@ -132,8 +142,13 @@ func cmdAddClaimsFromFile(c *cli.Context) error {
 
 		var indexSlot [400 / 8]byte
 		var dataSlot [496 / 8]byte
-		copy(indexSlot[:], line[0][:400/8])
-		copy(dataSlot[:], line[1][:496/8])
+		if len(line[0]) != len(indexSlot) || len(line[1]) != len(dataSlot) {
+			return fmt.Errorf(
+				"Length of indexSlot and dataSlot must be %v and %v respectively",
+				len(indexSlot), len(dataSlot))
+		}
+		copy(indexSlot[:], line[0])
+		copy(dataSlot[:], line[1])
 		claim := core.NewClaimBasic(indexSlot, dataSlot)
 		fmt.Println("clam: " + common3.BytesToHex(claim.Entry().Bytes()))
 

--- a/cmd/relay/commands/claim.go
+++ b/cmd/relay/commands/claim.go
@@ -51,20 +51,24 @@ func cmdAddClaim(c *cli.Context) error {
 	indexData := c.Args().Get(0)
 	outData := c.Args().Get(1)
 
-	claim := core.NewGenericClaim("iden3.io", "generic", []byte(indexData), []byte(outData))
-	fmt.Println("clam: " + common3.BytesToHex(claim.Bytes()))
+	var indexSlot [400 / 8]byte
+	var dataSlot [496 / 8]byte
+	copy(indexSlot[:], indexData[:400/8])
+	copy(dataSlot[:], outData[:496/8])
+	claim := core.NewClaimBasic(indexSlot, dataSlot)
+	fmt.Println("clam: " + common3.BytesToHex(claim.Entry().Bytes()))
 
-	err := claimservice.AddDirectClaim(claim)
+	err := claimservice.AddDirectClaim(*claim)
 	if err != nil {
 		return err
 	}
-	fmt.Print("root updated: " + mt.Root().Hex())
+	fmt.Print("root updated: " + mt.RootKey().Hex())
 
-	mp, err := mt.GenerateProof(claim.Hi())
+	mp, err := mt.GenerateProof(claim.Entry().HIndex())
 	if err != nil {
 		return err
 	}
-	fmt.Print("merkleproof: " + common3.BytesToHex(mp))
+	fmt.Print("merkleproof: " + common3.BytesToHex(mp.Bytes()))
 
 	return nil
 }
@@ -98,11 +102,16 @@ func cmdAddClaimsFromFile(c *cli.Context) error {
 
 		fmt.Println("importing claim with index: " + line[0] + ", outside index: " + line[1])
 
-		claim := core.NewGenericClaim("iden3.io", "generic", []byte(line[0]), []byte(line[1]))
-		fmt.Println("clam: " + common3.BytesToHex(claim.Bytes()) + "\n")
+		var indexSlot [400 / 8]byte
+		var dataSlot [496 / 8]byte
+		copy(indexSlot[:], line[0][:400/8])
+		copy(dataSlot[:], line[1][:496/8])
+		claim := core.NewClaimBasic(indexSlot, dataSlot)
+		// claim := core.NewGenericClaim("iden3.io", "generic", []byte(line[0]), []byte(line[1]))
+		fmt.Println("clam: " + common3.BytesToHex(claim.Entry().Bytes()) + "\n")
 
 		// add claim to merkletree, without updating the root, that will be done on the end of the loop (csv file)
-		err = mt.Add(claim)
+		err = mt.Add(claim.Entry())
 		if err != nil {
 			return err
 		}
@@ -121,19 +130,23 @@ func cmdAddClaimsFromFile(c *cli.Context) error {
 
 		fmt.Println("generating merkleproof of claim with index: " + line[0] + ", outside index: " + line[1])
 
-		claim := core.NewGenericClaim("iden3.io", "generic", []byte(line[0]), []byte(line[1]))
-		fmt.Println("clam: " + common3.BytesToHex(claim.Bytes()))
+		var indexSlot [400 / 8]byte
+		var dataSlot [496 / 8]byte
+		copy(indexSlot[:], line[0][:400/8])
+		copy(dataSlot[:], line[1][:496/8])
+		claim := core.NewClaimBasic(indexSlot, dataSlot)
+		fmt.Println("clam: " + common3.BytesToHex(claim.Entry().Bytes()))
 
 		// the proofs better generate them once all claims are added
-		mp, err := mt.GenerateProof(claim.Hi())
+		mp, err := mt.GenerateProof(claim.Entry().HIndex())
 		if err != nil {
 			return err
 		}
-		fmt.Println("merkleproof: " + common3.BytesToHex(mp) + "\n")
+		fmt.Println("merkleproof: " + common3.BytesToHex(mp.Bytes()) + "\n")
 	}
 	// update the root in the smart contract
-	rootservice.SetRoot(mt.Root())
-	fmt.Println("merkletree root: " + mt.Root().Hex())
+	rootservice.SetRoot(*mt.RootKey())
+	fmt.Println("merkletree root: " + mt.RootKey().Hex())
 
 	return nil
 }

--- a/cmd/relay/config/load.go
+++ b/cmd/relay/config/load.go
@@ -68,9 +68,9 @@ func LoadStorage() db.Storage {
 
 func LoadMerkele(storage db.Storage) *merkletree.MerkleTree {
 	mtstorage := storage.WithPrefix(dbMerkletreePrefix)
-	mt, err := merkletree.New(mtstorage, 140)
+	mt, err := merkletree.NewMerkleTree(mtstorage, 140)
 	assert("Cannot open merkle tree", err)
-	log.WithField("hash", mt.Root().Hex()).Info("Current root")
+	log.WithField("hash", mt.RootKey().Hex()).Info("Current root")
 
 	return mt
 }

--- a/cmd/relay/endpoint/admin.go
+++ b/cmd/relay/endpoint/admin.go
@@ -46,17 +46,30 @@ func handleMimc7(c *gin.Context) {
 	c.String(http.StatusOK, r.String())
 }
 
-type addGenericClaimMsg struct {
+type addClaimBasicMsg struct {
 	Namespace string
 	IndexData string
 	Data      string
 }
 
-func handleAddGenericClaim(c *gin.Context) {
-	var m addGenericClaimMsg
+func handleAddClaimBasic(c *gin.Context) {
+	var m addClaimBasicMsg
 	c.BindJSON(&m)
 
-	proofOfClaim, err := adminservice.AddGenericClaim([]byte(m.IndexData), []byte(m.Data))
+	if len(m.IndexData) != 400/8 {
+		c.String(http.StatusBadRequest, "indexData smaller than 400/8")
+		return
+	}
+	if len(m.Data) != 496/8 {
+		c.String(http.StatusBadRequest, "data smaller than 496/8")
+		return
+	}
+
+	var indexSlot [400 / 8]byte
+	var dataSlot [496 / 8]byte
+	copy(indexSlot[:], m.IndexData[:400/8])
+	copy(dataSlot[:], m.Data[:496/8])
+	proofOfClaim, err := adminservice.AddClaimBasic(indexSlot, dataSlot)
 	if err != nil {
 		c.String(http.StatusBadRequest, err.Error())
 	}

--- a/cmd/relay/endpoint/name.go
+++ b/cmd/relay/endpoint/name.go
@@ -15,13 +15,13 @@ func handleVinculateID(c *gin.Context) {
 	}
 
 	// return claim with proofs
-	proofOfRelayClaim, err := claimservice.GetRelayClaimByHi(assignNameClaim.Hi())
+	proofOfRelayClaim, err := claimservice.GetRelayClaimByHi(*assignNameClaim.Entry().HIndex())
 	if err != nil {
 		fail(c, "error on GetClaimByHi", err)
 		return
 	}
 	c.JSON(200, gin.H{
-		"assignNameClaim":   common3.BytesToHex(assignNameClaim.Bytes()),
+		"assignNameClaim":   common3.BytesToHex(assignNameClaim.Entry().Bytes()),
 		"name":              vinculateIDMsg.Name,
 		"ethID":             assignNameClaim.EthID,
 		"proofOfRelayClaim": proofOfRelayClaim.Hex(),
@@ -30,13 +30,13 @@ func handleVinculateID(c *gin.Context) {
 func handleAssignNameClaimResolv(c *gin.Context) {
 	nameid := c.Param("nameid")
 
-	assignNameClaim, err := nameservice.ResolvAssignNameClaim(nameid)
+	assignNameClaim, err := nameservice.ResolvClaimAssignName(nameid)
 	if err != nil {
 		fail(c, "nameid not found in merkletree", err)
 		return
 	}
 	c.JSON(200, gin.H{
-		"claim": common3.BytesToHex(assignNameClaim.Bytes()),
+		"claim": common3.BytesToHex(assignNameClaim.Entry().Bytes()),
 		"ethID": assignNameClaim.EthID,
 	})
 }

--- a/cmd/relay/endpoint/relay.go
+++ b/cmd/relay/endpoint/relay.go
@@ -16,7 +16,7 @@ func handleGetRoot(c *gin.Context) {
 		return
 	}
 	c.JSON(200, gin.H{
-		"root":         claimservice.MT().Root().Hex(),
+		"root":         claimservice.MT().RootKey().Hex(),
 		"contractRoot": common3.BytesToHex(root[:]),
 	})
 }

--- a/cmd/relay/endpoint/serve.go
+++ b/cmd/relay/endpoint/serve.go
@@ -76,7 +76,7 @@ func serveAdminApi(stopch chan interface{}) *http.Server {
 	adminapi.POST("/rawimport", handleRawImport)
 	adminapi.GET("/claimsdump", handleClaimsDump)
 	adminapi.POST("/mimc7", handleMimc7)
-	adminapi.POST("/genericClaim", handleAddGenericClaim)
+	adminapi.POST("/claims/basic", handleAddClaimBasic)
 
 	adminapisrv := &http.Server{Addr: config.C.Server.AdminApi, Handler: adminapi}
 	go func() {

--- a/core/claim_test.go
+++ b/core/claim_test.go
@@ -37,7 +37,7 @@ func TestClaimBasic(t *testing.T) {
 		0x58, 0x58, 0x58, 0x58, 0x58, 0x59}
 	c0 := NewClaimBasic(indexSlot, dataSlot)
 	c0.Version = 1
-	e := c0.ToEntry()
+	e := c0.Entry()
 	assert.Equal(t, "0x0d1770cf7af29da78eb31086bfa35a5945f39a8c4fa35edee71ac12a75b4a30b", e.HIndex().Hex())
 	assert.Equal(t, "0x14869ce50566e440424a2571816b117d88a2e5e3d10a0abb7f89a89032b9e07f", e.HValue().Hex())
 	assert.Equal(t, ""+
@@ -46,11 +46,11 @@ func TestClaimBasic(t *testing.T) {
 		"00292a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a"+
 		"002a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2b000000015735944c6eb8f12d",
 		e.Data.String())
-	c1 := NewClaimBasicFromEntry(&e)
-	c2, err := NewClaimFromEntry(&e)
+	c1 := NewClaimBasicFromEntry(e)
+	c2, err := NewClaimFromEntry(e)
 	assert.Nil(t, err)
 	assert.Equal(t, c0, c1)
-	assert.Equal(t, &c0, c2)
+	assert.Equal(t, c0, c2)
 }
 
 func TestClaimAssignName(t *testing.T) {
@@ -62,7 +62,7 @@ func TestClaimAssignName(t *testing.T) {
 		0x39, 0x39, 0x39, 0x3a})
 	c0 := NewClaimAssignName(name, ethID)
 	c0.Version = 1
-	e := c0.ToEntry()
+	e := c0.Entry()
 	assert.Equal(t, "0x23966b07b31bad5aebd8af6c72c7650f8ab45886e442f427da6c1bce73dbd2bb", e.HIndex().Hex())
 	assert.Equal(t, "0x279689e54ed1540614ba9ca682a01e83eb8b6aa3abf85b1f659fd537a75c5d6a", e.HValue().Hex())
 	assert.Equal(t, ""+
@@ -71,11 +71,11 @@ func TestClaimAssignName(t *testing.T) {
 		"00d67b05d8e2d1ace8f3e84b8451dd2e9da151578c3c6be23e7af11add5a807a"+
 		"000000000000000000000000000000000000000000000001f60d928459d792ed",
 		e.Data.String())
-	c1 := NewClaimAssignNameFromEntry(&e)
-	c2, err := NewClaimFromEntry(&e)
+	c1 := NewClaimAssignNameFromEntry(e)
+	c2, err := NewClaimFromEntry(e)
 	assert.Nil(t, err)
 	assert.Equal(t, c0, c1)
-	assert.Equal(t, &c0, c2)
+	assert.Equal(t, c0, c2)
 }
 
 func TestClaimAuthorizeKSign(t *testing.T) {
@@ -89,7 +89,7 @@ func TestClaimAuthorizeKSign(t *testing.T) {
 		0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x08}
 	c0 := NewClaimAuthorizeKSign(sign, ax, ay)
 	c0.Version = 1
-	e := c0.ToEntry()
+	e := c0.Entry()
 	assert.Equal(t, "0x18f1032141d6a2abda87e2cf053edcffb5be55ba0dc4c5a9073805c4aa7aee54", e.HIndex().Hex())
 	assert.Equal(t, "0x15331daa10ae035babcaabb76a80198bc449d32240ebb7f456ff2b03cd69bca4", e.HValue().Hex())
 	assert.Equal(t, ""+
@@ -98,11 +98,11 @@ func TestClaimAuthorizeKSign(t *testing.T) {
 		"0000000000000000000000000000000007070707070707070707070707070708"+
 		"0000000505050505050505050505050505050601000000015714c3724876e56d",
 		e.Data.String())
-	c1 := NewClaimAuthorizeKSignFromEntry(&e)
-	c2, err := NewClaimFromEntry(&e)
+	c1 := NewClaimAuthorizeKSignFromEntry(e)
+	c2, err := NewClaimFromEntry(e)
 	assert.Nil(t, err)
 	assert.Equal(t, c0, c1)
-	assert.Equal(t, &c0, c2)
+	assert.Equal(t, c0, c2)
 }
 
 func TestClaimSetRootKey(t *testing.T) {
@@ -119,7 +119,7 @@ func TestClaimSetRootKey(t *testing.T) {
 	c0 := NewClaimSetRootKey(ethID, rootKey)
 	c0.Version = 1
 	c0.Era = 1
-	e := c0.ToEntry()
+	e := c0.Entry()
 	assert.Equal(t, "0x0a2d38687ea5f987637ded13030b22d1657be60bdb35add74bb53c8d5d126f8f", e.HIndex().Hex())
 	assert.Equal(t, "0x2e27903d404fcab9363967a4ffe7da6a615f9ce6f55c43661a0297a040d336a4", e.HValue().Hex())
 	assert.Equal(t, ""+
@@ -128,11 +128,11 @@ func TestClaimSetRootKey(t *testing.T) {
 		"000000000000000000000000393939393939393939393939393939393939393a"+
 		"000000000000000000000000000000000000000100000001b111df93ad32c22c",
 		e.Data.String())
-	c1 := NewClaimSetRootKeyFromEntry(&e)
-	c2, err := NewClaimFromEntry(&e)
+	c1 := NewClaimSetRootKeyFromEntry(e)
+	c2, err := NewClaimFromEntry(e)
 	assert.Nil(t, err)
 	assert.Equal(t, c0, c1)
-	assert.Equal(t, &c0, c2)
+	assert.Equal(t, c0, c2)
 }
 
 func dataTestOutput(d *merkletree.Data) string {

--- a/db/leveldb.go
+++ b/db/leveldb.go
@@ -84,6 +84,7 @@ func (l *LevelDbStorage) Get(key []byte) ([]byte, error) {
 }
 
 func (l *LevelDbStorage) Iterate(f func([]byte, []byte)) error {
+	// WARNING iterate doesn't use the prefix
 	snapshot, err := l.ldb.GetSnapshot()
 	if err != nil {
 		return err

--- a/merkletree/merkletree_test.go
+++ b/merkletree/merkletree_test.go
@@ -517,7 +517,7 @@ func TestDbInsertGet(t *testing.T) {
 
 	nodeType, data, err := mt.dbGet(key)
 	assert.Nil(t, err)
-	assert.Equal(t, byte(9), nodeType)
+	assert.Equal(t, NodeType(9), nodeType)
 	assert.Equal(t, []byte("value"), data)
 
 }

--- a/merkletree/node.go
+++ b/merkletree/node.go
@@ -14,6 +14,9 @@ const (
 	NodeTypeLeaf NodeType = 1
 	// NodeTypeEmpty indicates the type of an empty Node.
 	NodeTypeEmpty NodeType = 2
+
+	// DBEntryTypeRoot indicates the type of a DB entry that indicates the current Root of a MerkleTree
+	DBEntryTypeRoot NodeType = 3
 )
 
 // Node is the struct that represents a node in the MT.

--- a/merkletreeDoc/example.go
+++ b/merkletreeDoc/example.go
@@ -1,15 +1,9 @@
 package main
 
-import (
-	"bytes"
-	"fmt"
+func main() {
+}
 
-	common3 "github.com/iden3/go-iden3/common"
-	"github.com/iden3/go-iden3/core"
-	"github.com/iden3/go-iden3/db"
-	"github.com/iden3/go-iden3/merkletree"
-)
-
+/*
 func main() {
 	storage, err := db.NewLevelDbStorage("./path", false)
 	if err != nil {
@@ -72,3 +66,4 @@ func main() {
 
 	fmt.Println("merkle proof of non existence checked:", checked)
 }
+*/

--- a/services/claimsrv/claimproofs.go
+++ b/services/claimsrv/claimproofs.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/iden3/go-iden3/core"
+	"github.com/iden3/go-iden3/db"
 	"github.com/iden3/go-iden3/merkletree"
 	"github.com/iden3/go-iden3/utils"
 )
@@ -101,7 +102,7 @@ func CheckKSignInIDdb(mt *merkletree.MerkleTree, ksign common.Address) bool {
 	entry = claimAuthorizeKSign.Entry()
 	node = merkletree.NewNodeLeaf(entry)
 	_, err = mt.GetNode(node.Key())
-	if err.Error() != "key not found" {
+	if err != db.ErrNotFound {
 		return false
 	}
 

--- a/services/claimsrv/claimproofs.go
+++ b/services/claimsrv/claimproofs.go
@@ -11,21 +11,53 @@ import (
 
 // CheckProofOfClaim checks the Merkle Proof of the Claim, the SetRootClaim, and the non revocation proof of both claims
 func CheckProofOfClaim(relayAddr common.Address, pc ProofOfClaim, numLevels int) bool {
-	hiClaim := core.HiFromClaimBytes(pc.ClaimProof.Leaf)
-	vClaimProof := merkletree.CheckProof(pc.ClaimProof.Root, pc.ClaimProof.Proof,
-		hiClaim, merkletree.HashBytes(pc.ClaimProof.Leaf), numLevels)
+	node, err := merkletree.NewNodeFromBytes(pc.ClaimProof.Leaf)
+	if err != nil {
+		return false
+	}
+	node.Entry.HIndex()
+	pf, err := merkletree.NewProofFromBytes(pc.ClaimProof.Proof)
+	if err != nil {
+		return false
+	}
+	vClaimProof := merkletree.VerifyProof(&pc.ClaimProof.Root, pf,
+		node.Entry.HIndex(), node.Entry.HValue())
 
-	hiSetRootClaim := core.HiFromClaimBytes(pc.SetRootClaimProof.Leaf)
-	vSetRootClaimProof := merkletree.CheckProof(pc.SetRootClaimProof.Root, pc.SetRootClaimProof.Proof,
-		hiSetRootClaim, merkletree.HashBytes(pc.SetRootClaimProof.Leaf), numLevels)
+	node, err = merkletree.NewNodeFromBytes(pc.SetRootClaimProof.Leaf)
+	if err != nil {
+		return false
+	}
+	node.Entry.HIndex()
+	pf, err = merkletree.NewProofFromBytes(pc.SetRootClaimProof.Proof)
+	if err != nil {
+		return false
+	}
+	vSetRootClaimProof := merkletree.VerifyProof(&pc.SetRootClaimProof.Root, pf,
+		node.Entry.HIndex(), node.Entry.HValue())
 
-	hiNonRevocationClaim := core.HiFromClaimBytes(pc.ClaimNonRevocationProof.Leaf)
-	vClaimNonRevocationProof := merkletree.CheckProof(pc.ClaimNonRevocationProof.Root, pc.ClaimNonRevocationProof.Proof,
-		hiNonRevocationClaim, merkletree.EmptyNodeValue, numLevels)
+	node, err = merkletree.NewNodeFromBytes(pc.ClaimNonRevocationProof.Leaf)
+	if err != nil {
+		return false
+	}
+	node.Entry.HIndex()
+	pf, err = merkletree.NewProofFromBytes(pc.ClaimNonRevocationProof.Proof)
+	if err != nil {
+		return false
+	}
+	vClaimNonRevocationProof := merkletree.VerifyProof(&pc.ClaimNonRevocationProof.Root, pf,
+		node.Entry.HIndex(), node.Entry.HValue())
 
-	hiNonRevocationSetRootClaim := core.HiFromClaimBytes(pc.SetRootClaimNonRevocationProof.Leaf)
-	vSetRootClaimNonRevocationProof := merkletree.CheckProof(pc.SetRootClaimNonRevocationProof.Root, pc.SetRootClaimNonRevocationProof.Proof,
-		hiNonRevocationSetRootClaim, merkletree.EmptyNodeValue, numLevels)
+	node, err = merkletree.NewNodeFromBytes(pc.SetRootClaimNonRevocationProof.Leaf)
+	if err != nil {
+		return false
+	}
+	node.Entry.HIndex()
+	pf, err = merkletree.NewProofFromBytes(pc.SetRootClaimNonRevocationProof.Proof)
+	if err != nil {
+		return false
+	}
+	vSetRootClaimNonRevocationProof := merkletree.VerifyProof(&pc.SetRootClaimNonRevocationProof.Root, pf,
+		node.Entry.HIndex(), node.Entry.HValue())
 
 	// additional, check caducity of the pc.Date
 
@@ -51,20 +83,24 @@ func CheckProofOfClaim(relayAddr common.Address, pc ProofOfClaim, numLevels int)
 // CheckKSignInIDdb checks that a given KSign is in an AuthorizeKSignClaim in the Identity Merkle Tree (in this version, as the Merkle Tree don't allows to delete data, the verification only needs to check if the AuthorizeKSignClaim is in the key-value)
 func CheckKSignInIDdb(mt *merkletree.MerkleTree, ksign common.Address) bool {
 	// generate the AuthorizeKSignClaim
-	authorizeKSignClaim := core.NewOperationalKSignClaim(ksign)
-	ht := authorizeKSignClaim.Ht()
-	value, err := mt.Storage().Get(ht[:])
+	var tmpFakeAx [16]byte
+	var tmpFakeAy [16]byte
+	claimAuthorizeKSign := core.NewClaimAuthorizeKSign(false, tmpFakeAx, tmpFakeAy) // TODO ethAddress to pubK
+	entry := claimAuthorizeKSign.Entry()
+	node := merkletree.NewNodeLeaf(entry)
+	nodeGetted, err := mt.GetNode(node.Key())
 	if err != nil {
 		return false
 	}
-	if !bytes.Equal(authorizeKSignClaim.Bytes(), value[5:]) { // value[5:] to skip the db prefix
+	if !bytes.Equal(node.Value(), nodeGetted.Value()) {
 		return false
 	}
 
 	// non revocation
-	authorizeKSignClaim.BaseIndex.Version++
-	ht = authorizeKSignClaim.Ht()
-	value, err = mt.Storage().Get(ht[:])
+	claimAuthorizeKSign.Version++
+	entry = claimAuthorizeKSign.Entry()
+	node = merkletree.NewNodeLeaf(entry)
+	_, err = mt.GetNode(node.Key())
 	if err.Error() != "key not found" {
 		return false
 	}

--- a/services/claimsrv/messages.go
+++ b/services/claimsrv/messages.go
@@ -14,21 +14,21 @@ type BytesSignedMsg struct {
 	KSign        common.Address `json:"ksign"`
 }
 
-// GenericClaimMsg contains a core.GenericClaim with its signature in Hex
-type GenericClaimMsg struct {
-	GenericClaim core.GenericClaim
-	Signature    string
+// ClaimBasicMsg contains a core.ClaimBasic with its signature in Hex
+type ClaimBasicMsg struct {
+	ClaimBasic core.ClaimBasic
+	Signature  string
 }
 
-// AssignNameClaimMsg contains a core.AssignNameClaim with its signature in Hex
-type AssignNameClaimMsg struct {
-	AssignNameClaim core.AssignNameClaim
+// ClaimAssignNameMsg contains a core.ClaimAssignName with its signature in Hex
+type ClaimAssignNameMsg struct {
+	ClaimAssignName core.ClaimAssignName
 	Signature       string
 }
 
-// AuthorizeKSignClaimMsg contains a core.AuthorizeKSignClaim with its signature in Hex
-type AuthorizeKSignClaimMsg struct {
-	AuthorizeKSignClaim core.AuthorizeKSignClaim
+// ClaimAuthorizeKSignMsg contains a core.AuthorizeKSignClaim with its signature in Hex
+type ClaimAuthorizeKSignMsg struct {
+	ClaimAuthorizeKSign core.ClaimAuthorizeKSign
 	Signature           string
 	KSign               common.Address
 }
@@ -44,7 +44,7 @@ type SetRootMsg struct {
 
 // ClaimValueMsg contains a core.ClaimValue with its signature in Hex
 type ClaimValueMsg struct {
-	ClaimValue merkletree.Value
+	ClaimValue merkletree.Entry
 	Signature  string
 	KSign      common.Address
 }

--- a/services/claimsrv/service.go
+++ b/services/claimsrv/service.go
@@ -541,6 +541,4 @@ func GetNextVersion(mt *merkletree.MerkleTree, hi *merkletree.Hash) (uint32, err
 		hi = entry.HIndex()
 		// hi = merkletree.HashBytes(value.Bytes()[:value.IndexLength()])
 	}
-	// return version
-	return version, nil
 }

--- a/services/claimsrv/service_test.go
+++ b/services/claimsrv/service_test.go
@@ -55,7 +55,7 @@ func newTestingMerkle(numLevels int) (*merkletree.MerkleTree, error) {
 		return &merkletree.MerkleTree{}, err
 	}
 
-	mt, err := merkletree.New(sto, numLevels)
+	mt, err := merkletree.NewMerkleTree(sto, numLevels)
 	return mt, err
 }
 
@@ -84,51 +84,77 @@ func initializeEnvironment(t *testing.T) {
 func TestGetNextVersion(t *testing.T) {
 	initializeEnvironment(t)
 
-	claim := core.NewGenericClaim("c1", "default", []byte("c1"), []byte{})
+	indexData := []byte("c1")
+	data := []byte{}
+	var indexSlot [400 / 8]byte
+	var dataSlot [496 / 8]byte
+	// copy(indexSlot[:], indexData[:400/8])
+	// copy(dataSlot[:], data[:496/8])
+	copy(indexSlot[:], indexData[:])
+	copy(dataSlot[:], data[:])
+	claim := core.NewClaimBasic(indexSlot, dataSlot)
 
-	version, err := GetNextVersion(mt, claim.Hi())
+	version, err := GetNextVersion(mt, claim.Entry().HIndex())
 	assert.Nil(t, err)
 	assert.Equal(t, uint32(0), version)
-	claim.BaseIndex.Version = version
-	mt.Add(claim)
-	version, err = GetNextVersion(mt, claim.Hi())
+	claim.Version = version
+	mt.Add(claim.Entry())
+	version, err = GetNextVersion(mt, claim.Entry().HIndex())
 	assert.Nil(t, err)
 	assert.Equal(t, uint32(1), version)
 
-	claim.BaseIndex.Version = version
-	mt.Add(claim)
-	version, err = GetNextVersion(mt, claim.Hi())
+	claim.Version = version
+	mt.Add(claim.Entry())
+	version, err = GetNextVersion(mt, claim.Entry().HIndex())
 	assert.Nil(t, err)
 	assert.Equal(t, uint32(2), version)
 
-	claim.BaseIndex.Version = version
-	mt.Add(claim)
-	version, err = GetNextVersion(mt, claim.Hi())
+	claim.Version = version
+	mt.Add(claim.Entry())
+	version, err = GetNextVersion(mt, claim.Entry().HIndex())
 	assert.Nil(t, err)
 	assert.Equal(t, uint32(3), version)
 
-	claim.BaseIndex.Version = version
-	mt.Add(claim)
-	version, err = GetNextVersion(mt, claim.Hi())
+	claim.Version = version
+	mt.Add(claim.Entry())
+	version, err = GetNextVersion(mt, claim.Entry().HIndex())
 	assert.Nil(t, err)
 	assert.Equal(t, uint32(4), version)
 }
 
 func TestGetNonRevocationProof(t *testing.T) {
 	initializeEnvironment(t)
-	claim := core.NewGenericClaim("c1", "default", []byte("c1"), []byte{})
+	indexData := []byte("c1")
+	data := []byte{}
+	var indexSlot [400 / 8]byte
+	var dataSlot [496 / 8]byte
+	copy(indexSlot[:], indexData[:])
+	copy(dataSlot[:], data[:])
+	claim := core.NewClaimBasic(indexSlot, dataSlot)
 
-	err := mt.Add(claim)
+	err := mt.Add(claim.Entry())
 	assert.Nil(t, err)
-	version, err := GetNextVersion(mt, claim.Hi())
+	version, err := GetNextVersion(mt, claim.Entry().HIndex())
 	assert.Nil(t, err)
 	assert.Equal(t, uint32(1), version)
 
-	claimProof, err := getNonRevocationProof(mt, claim.Hi())
+	claimProof, err := getNonRevocationProof(mt, *claim.Entry().HIndex())
 	assert.Nil(t, err)
-	assert.Equal(t, "0x000000000000000000000000000000000000000000000000000000000000020012174493a3222e491377aae3a1ed614ab1277c8651a9c97954c199d1ce1cb4e4", common3.BytesToHex(claimProof.Proof))
-	assert.Equal(t, "0xbdecf4eaaaf0d632fa2a0eb291219b766d59959abfa3695ca202d60f294b14f4", claimProof.Root.Hex())
-	verified := merkletree.CheckProof(claimProof.Root, claimProof.Proof, core.HiFromClaimBytes(claimProof.Leaf), merkletree.EmptyNodeValue, mt.NumLevels())
+
+	assert.Equal(t, "0x03000000000000000000000000000000000000000000000000000000000000001988e8353a8e69db77d624dff1b3b0cc6092963cc6c2e9163dbecf75ddeb11c015331daa10ae035babcaabb76a80198bc449d32240ebb7f456ff2b03cd69bca4", common3.BytesToHex(claimProof.Proof))
+	assert.Equal(t, "0x1354ca3c5ae9b7401bea0e22280580511734075a792784ccd6a0713e1acba19e", claimProof.Root.Hex())
+
+	proof, err := merkletree.NewProofFromBytes(claimProof.Proof)
+	assert.Nil(t, err)
+
+	// VerifyProof with HIndex and HValue from claimProof.Leaf
+	var leafBytes [128]byte
+	copy(leafBytes[:], claimProof.Leaf)
+	dataNonE := merkletree.BytesToData(leafBytes)
+	claimProofEntry := merkletree.Entry{
+		Data: *dataNonE,
+	}
+	verified := merkletree.VerifyProof(&claimProof.Root, proof, claimProofEntry.HIndex(), claimProofEntry.HValue())
 	assert.True(t, verified)
 }
 
@@ -137,51 +163,84 @@ func TestGetClaimByHi(t *testing.T) {
 	initializeEnvironment(t)
 
 	ethID := common.HexToAddress("0x970E8128AB834E8EAC17Ab8E3812F010678CF791")
-	namespace := "iden3.io"
-	claim := core.NewGenericClaim(namespace, "default", []byte("dataasdf"), []byte{})
+
+	indexData := []byte("data01")
+	data := []byte{}
+	var indexSlot [400 / 8]byte
+	var dataSlot [496 / 8]byte
+	copy(indexSlot[:], indexData[:])
+	copy(dataSlot[:], data[:])
+	claim := core.NewClaimBasic(indexSlot, dataSlot)
+
 	// get the user's id storage, using the user id prefix (the idaddress itself)
 	stoUserID := mt.Storage().WithPrefix(ethID.Hash().Bytes())
 	// open the MerkleTree of the user
-	userMT, err := merkletree.New(stoUserID, 140)
+	userMT, err := merkletree.NewMerkleTree(stoUserID, 140)
 	assert.Nil(t, err)
 
 	// add claim in User ID Merkle Tree
-	err = userMT.Add(claim)
+	err = userMT.Add(claim.Entry())
 	assert.Nil(t, err)
 
 	// setRootClaim of the user in the Relay Merkle Tree
-	setRootClaim := core.NewSetRootClaim(namespace, ethID, userMT.Root())
+	setRootClaim := core.NewClaimSetRootKey(ethID, *userMT.RootKey())
 	// setRootClaim.BaseIndex.Version++ // TODO autoincrement
 	// add User's ID Merkle Root into the Relay's Merkle Tree
-	err = mt.Add(setRootClaim)
+	err = mt.Add(setRootClaim.Entry())
 	assert.Nil(t, err)
 
-	claimProof, setRootClaimProof, claimNonRevocationProof, setRootClaimNonRevocationProof, err := service.GetClaimByHi(namespace, ethID, claim.Hi())
+	proofOfClaim, err := service.GetClaimByHi(ethID, *claim.Entry().HIndex())
 	assert.Nil(t, err)
+	if err != nil {
+		panic(err)
+	}
+	claimProof := proofOfClaim.ClaimProof
+	claimNonRevocationProof := proofOfClaim.ClaimNonRevocationProof
+	setRootClaimProof := proofOfClaim.SetRootClaimProof
+	setRootClaimNonRevocationProof := proofOfClaim.SetRootClaimNonRevocationProof
+
 	assert.Equal(t, "0x3cfc3a1edbf691316fec9b75970fbfb2b0e8d8edfc6ec7628db77c4969403074cfee7c08a98f4b565d124c7e4e28acc52e1bc780e3887db000000048000000006461746161736466", common3.BytesToHex(claimProof.Leaf))
 	assert.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000000", common3.BytesToHex(claimProof.Proof))
 	assert.Equal(t, "0x1415376b054a9ab3c7f9bd0ec956b0f403ae98d7e37dcbafdf26b465b23dd970", claimProof.Root.Hex())
 	assert.Equal(t, "0x3cfc3a1edbf691316fec9b75970fbfb2b0e8d8edfc6ec7628db77c49694030749b9a76a0132a0814192c05c9321efc30c7286f6187f18fc60000005400000000970e8128ab834e8eac17ab8e3812f010678cf7911415376b054a9ab3c7f9bd0ec956b0f403ae98d7e37dcbafdf26b465b23dd970", common3.BytesToHex(setRootClaimProof.Leaf))
 	assert.Equal(t, "0x000000000000000000000000000000000000000000000000000000000000000474c3e76aebd3df03ff91325d245e72ea9ad9599777f5d2c5e560b3f049d68309", common3.BytesToHex(setRootClaimProof.Proof))
 	assert.Equal(t, "0xf73c98cbaa1d43ada4ed5520300c348985dd47cc283e3cf7186434a07a46886a", setRootClaimProof.Root.Hex())
-	assert.Equal(t, "0x7911db4d851195222b57a615fae3920fd230bbb2194003433c32c1d6628b7c16", claimNonRevocationProof.Hi.Hex())
 	assert.Equal(t, "0x00000000000000000000000000000000000000000000000000000000000000025563046fb69f065953f0fdb0b3033f721457184adfae2824c02932090bf8f281", common3.BytesToHex(claimNonRevocationProof.Proof))
-	assert.Equal(t, "0xd5281581e6c4888d32ab0e87a5f54bc73c0f268ee506dbacaae01a412136c1a2", setRootClaimNonRevocationProof.Hi.Hex())
 	assert.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000014367d7c39348c9b7f2d488a7cd2edfbae56d608ec92a1b0a747adda3c4aaf763d74c3e76aebd3df03ff91325d245e72ea9ad9599777f5d2c5e560b3f049d68309", common3.BytesToHex(setRootClaimNonRevocationProof.Proof))
 
 	assert.Equal(t, claimProof.Root.Bytes(), claimNonRevocationProof.Root.Bytes())
 	assert.Equal(t, setRootClaimProof.Root.Bytes(), setRootClaimNonRevocationProof.Root.Bytes())
 
-	verified := merkletree.CheckProof(claimProof.Root, claimProof.Proof, claimProof.Hi, merkletree.HashBytes(claimProof.Leaf), 140)
+	var leafBytes [128]byte
+	copy(leafBytes[:], claimProof.Leaf)
+	entry := merkletree.Entry{Data: *merkletree.BytesToData(leafBytes)}
+	proof, err := merkletree.NewProofFromBytes(claimProof.Proof)
+	assert.Nil(t, err)
+	verified := merkletree.VerifyProof(&claimProof.Root, proof, entry.HIndex(), entry.HValue())
 	assert.True(t, verified)
 
-	verified = merkletree.CheckProof(setRootClaimProof.Root, setRootClaimProof.Proof, setRootClaimProof.Hi, merkletree.HashBytes(setRootClaimProof.Leaf), 140)
+	leafBytes = [128]byte{}
+	copy(leafBytes[:], setRootClaimProof.Leaf)
+	entry = merkletree.Entry{Data: *merkletree.BytesToData(leafBytes)}
+	proof, err = merkletree.NewProofFromBytes(setRootClaimProof.Proof)
+	assert.Nil(t, err)
+	verified = merkletree.VerifyProof(&setRootClaimProof.Root, proof, entry.HIndex(), entry.HValue())
 	assert.True(t, verified)
 
-	verified = merkletree.CheckProof(claimNonRevocationProof.Root, claimNonRevocationProof.Proof, claimNonRevocationProof.Hi, merkletree.EmptyNodeValue, 140)
+	leafBytes = [128]byte{}
+	copy(leafBytes[:], claimNonRevocationProof.Leaf)
+	entry = merkletree.Entry{Data: *merkletree.BytesToData(leafBytes)}
+	proof, err = merkletree.NewProofFromBytes(claimNonRevocationProof.Proof)
+	assert.Nil(t, err)
+	verified = merkletree.VerifyProof(&claimNonRevocationProof.Root, proof, entry.HIndex(), entry.HValue())
 	assert.True(t, verified)
 
-	verified = merkletree.CheckProof(setRootClaimNonRevocationProof.Root, setRootClaimNonRevocationProof.Proof, setRootClaimNonRevocationProof.Hi, merkletree.EmptyNodeValue, 140)
+	leafBytes = [128]byte{}
+	copy(leafBytes[:], setRootClaimNonRevocationProof.Leaf)
+	entry = merkletree.Entry{Data: *merkletree.BytesToData(leafBytes)}
+	proof, err = merkletree.NewProofFromBytes(setRootClaimNonRevocationProof.Proof)
+	assert.Nil(t, err)
+	verified = merkletree.VerifyProof(&setRootClaimNonRevocationProof.Root, proof, entry.HIndex(), entry.HValue())
 	assert.True(t, verified)
 }
 */

--- a/services/identitysrv/service.go
+++ b/services/identitysrv/service.go
@@ -183,8 +183,13 @@ func (s *ServiceImpl) Forward(
 	sig []byte,
 ) (common.Hash, error) {
 
-	ksignclaim := core.NewOperationalKSignClaim(ksignkey)
-	proof, err := s.cs.GetClaimByHi(idaddr, ksignclaim.Hi())
+	// ksignclaim := core.NewOperationalKSignClaim(ksignkey)
+	// TODO get the sign, ax, ay values
+	sign := true
+	ax := [128 / 8]byte{}
+	ay := [128 / 8]byte{}
+	ksignclaim := core.NewClaimAuthorizeKSign(sign, ax, ay) // TODO
+	proof, err := s.cs.GetClaimByHi(idaddr, *ksignclaim.Entry().HIndex())
 	if err != nil {
 		log.Warn("Error retieving proof ", err)
 		return common.Hash{}, err
@@ -239,8 +244,13 @@ func (s *ServiceImpl) Add(id *Identity) error {
 		return err
 	}
 
-	claim := core.NewOperationalKSignClaim(id.Operational)
-	return s.cs.AddAuthorizeKSignClaimFirst(idaddr, claim)
+	// TODO get the sign, ax, ay values
+	sign := true
+	ax := [128 / 8]byte{}
+	ay := [128 / 8]byte{}
+	claim := core.NewClaimAuthorizeKSign(sign, ax, ay) // TODO
+	// claim := core.NewOperationalKSignClaim(id.Operational)
+	return s.cs.AddClaimAuthorizeKSignFirst(idaddr, *claim)
 }
 
 func (m *ServiceImpl) List(limit int) ([]common.Address, error) {


### PR DESCRIPTION
…ests with the rest of the Go code

wip

claimsrv compiling

adminsrv, claimsrv, identitysrv, namesrv not failing on build

wip. relay compiling

claim.Entry(), passing tests

wip, admin cli endpoints

wip, adding merkletree store current Root in db, and get current Root from db when opening a MerkleTree DataBase

store current merkletree root in db and use it when opening merkletree