### PR TITLE
Add Genesis Identity MerkleTree, alternative to Counterfactual Id

### DIFF
--- a/cmd/relay/endpoint/id.go
+++ b/cmd/relay/endpoint/id.go
@@ -50,6 +50,36 @@ type handleForwardIdRes struct {
 	Tx common.Hash `json:"tx"`
 }
 
+type handleIdGenesis struct {
+	KOp   *utils.PublicKey
+	KRec  *utils.PublicKey
+	KRev  *utils.PublicKey
+	Relay common.Address
+}
+
+// handleCreateIdGenesis creates the identity creating a new MerkleTree that contains
+// the initial keys of that identity. The Merkle Root of that tree will be the
+// identity address
+func handleCreateIdGenesis(c *gin.Context) {
+	var idgen handleIdGenesis
+	if err := c.BindJSON(&idgen); err != nil {
+		genericserver.Fail(c, "cannot parse json body", err)
+		return
+	}
+
+	kopPub := &idgen.KOp.PublicKey
+	krecPub := &idgen.KRec.PublicKey
+	krevPub := &idgen.KRev.PublicKey
+
+	idAddr, proofKOp, err := genericserver.Idservice.CreateIdGenesis(kopPub, krecPub, krevPub)
+	if err != nil {
+		genericserver.Fail(c, "failed generating identity address ", err)
+		return
+	}
+
+	c.JSON(http.StatusOK, handlePostIdRes{IdAddr: *idAddr, ProofClaim: proofKOp})
+}
+
 // handleCreateId handles the creation of a new user tree from the user keys.
 func handleCreateId(c *gin.Context) {
 

--- a/cmd/relay/endpoint/serve.go
+++ b/cmd/relay/endpoint/serve.go
@@ -26,6 +26,7 @@ func serveServiceApi() *http.Server {
 	serviceapi.GET("/claims/:hi/proof", handleGetClaimProofByHi) // Get relay claim proof
 
 	serviceapi.POST("/ids", handleCreateId)
+	serviceapi.POST("/idgenesis", handleCreateIdGenesis)
 	serviceapi.GET("/ids/:idaddr", handleGetId)
 	serviceapi.POST("/ids/:idaddr/deploy", handleDeployId)
 	serviceapi.POST("/ids/:idaddr/forward", handleForwardId)

--- a/services/claimsrv/service.go
+++ b/services/claimsrv/service.go
@@ -34,6 +34,7 @@ type Service interface {
 	GetClaimProofUserByHiOld(idAddr common.Address, hi merkletree.Hash) (*ProofClaimUser, error)
 	GetClaimProofByHi(hi *merkletree.Hash) (*core.ProofClaim, error)
 	MT() *merkletree.MerkleTree
+	RootSrv() rootsrv.Service
 }
 
 type ServiceImpl struct {
@@ -46,6 +47,16 @@ type ServiceImpl struct {
 func New(idAddr common.Address, mt *merkletree.MerkleTree, rootsrv rootsrv.Service,
 	signer signsrv.Service) *ServiceImpl {
 	return &ServiceImpl{idAddr, mt, rootsrv, signer}
+}
+
+// MT returns the merkle tree.
+func (cs *ServiceImpl) MT() *merkletree.MerkleTree {
+	return cs.mt
+}
+
+// RootSrv returns the RootService
+func (cs *ServiceImpl) RootSrv() rootsrv.Service {
+	return cs.rootsrv
 }
 
 // SetNewIdRoot checks that the data is valid and performs a claim in the Relay merkletree setting the new Root of the emiting Id
@@ -575,11 +586,6 @@ func (cs *ServiceImpl) GetClaimProofByHi(hi *merkletree.Hash) (*core.ProofClaim,
 	proofClaim.Signer, proofClaim.Signature, proofClaim.Date = cs.idAddr, sig, date
 
 	return proofClaim, nil
-}
-
-// MT returns the merkle tree.
-func (cs *ServiceImpl) MT() *merkletree.MerkleTree {
-	return cs.mt
 }
 
 // getNonRevocationProof returns the next version Hi (that don't exist in the tree, it's value is Empty) with merkleproof and root

--- a/services/identitysrv/service_test.go
+++ b/services/identitysrv/service_test.go
@@ -1,11 +1,26 @@
 package identitysrv
 
 import (
+	"crypto/ecdsa"
 	"encoding/hex"
+	"fmt"
+	"io/ioutil"
 	"testing"
+	"time"
 
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	common3 "github.com/iden3/go-iden3/common"
+	"github.com/iden3/go-iden3/core"
+	"github.com/iden3/go-iden3/db"
+	"github.com/iden3/go-iden3/merkletree"
+	"github.com/iden3/go-iden3/services/claimsrv"
+	"github.com/iden3/go-iden3/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
+
+var debug = false
 
 func TestPack(t *testing.T) {
 
@@ -27,4 +42,161 @@ func TestPack(t *testing.T) {
 
 	assert.Equal(t, hex.EncodeToString(expected), hex.EncodeToString(actual))
 
+}
+
+var relaySecKey *ecdsa.PrivateKey
+var relayPubKey *ecdsa.PublicKey
+var relayAddr common.Address
+
+type RootServiceMock struct {
+	mock.Mock
+}
+
+func (m *RootServiceMock) Start() {
+
+}
+func (m *RootServiceMock) StopAndJoin() {
+
+}
+
+func (m *RootServiceMock) GetRoot(addr common.Address) (merkletree.Hash, error) {
+	args := m.Called(addr)
+	return args.Get(0).(merkletree.Hash), args.Error(1)
+}
+func (m *RootServiceMock) SetRoot(hash merkletree.Hash) {
+	m.Called(hash)
+	return
+}
+
+type SignServiceMock struct {
+	mock.Mock
+}
+
+func (m *SignServiceMock) SignEthMsg(msg []byte) (*utils.SignatureEthMsg, error) {
+	h := utils.EthHash(msg)
+	sig, err := crypto.Sign(h[:], relaySecKey)
+	if err != nil {
+		return nil, err
+	}
+	sig[64] += 27
+	sigEthMsg := &utils.SignatureEthMsg{}
+	copy(sigEthMsg[:], sig)
+	return sigEthMsg, nil
+}
+
+func (m *SignServiceMock) SignEthMsgDate(msg []byte) (*utils.SignatureEthMsg, int64, error) {
+	dateInt64 := time.Now().Unix()
+	dateBytes := utils.Uint64ToEthBytes(uint64(dateInt64))
+	sig, err := m.SignEthMsg(append(msg, dateBytes...))
+	return sig, dateInt64, err
+}
+
+func newTestingMerkle(numLevels int) (*merkletree.MerkleTree, error) {
+	dir, err := ioutil.TempDir("", "db")
+	if err != nil {
+		return &merkletree.MerkleTree{}, err
+	}
+	sto, err := db.NewLevelDbStorage(dir, false)
+	if err != nil {
+		return &merkletree.MerkleTree{}, err
+	}
+
+	mt, err := merkletree.NewMerkleTree(sto, numLevels)
+	return mt, err
+}
+func initializeIdService(t *testing.T) *ServiceImpl {
+
+	// MerkleTree leveldb
+	mt, err := newTestingMerkle(140)
+	if err != nil {
+		t.Error(err)
+	}
+	sto := db.NewMemoryStorage()
+	rootservicemock := &RootServiceMock{}
+	rootservicemock.On("SetRoot", mock.Anything).Return()
+	claimService := claimsrv.New(mt, rootservicemock, &SignServiceMock{})
+	idService := New(nil, nil, nil, claimService, sto)
+
+	secKeyHex := "79156abe7fe2fd433dc9df969286b96666489bac508612d0e16593e944c4f69f"
+	relaySecKey, err = crypto.HexToECDSA(secKeyHex)
+	if err != nil {
+		panic(err)
+	}
+	relayPubKey = relaySecKey.Public().(*ecdsa.PublicKey)
+	relayAddr = crypto.PubkeyToAddress(*relayPubKey)
+
+	return idService
+}
+
+func TestCreateIdGenesisRandom(t *testing.T) {
+	idsrv := initializeIdService(t)
+
+	kop, err := crypto.GenerateKey()
+	assert.Nil(t, err)
+	kopPub := kop.Public().(*ecdsa.PublicKey)
+	if debug {
+		fmt.Println("kop", common3.HexEncode(crypto.CompressPubkey(kopPub)))
+	}
+	krec, err := crypto.GenerateKey()
+	assert.Nil(t, err)
+	krecPub := krec.Public().(*ecdsa.PublicKey)
+	if debug {
+		fmt.Println("krec", common3.HexEncode(crypto.CompressPubkey(krecPub)))
+	}
+	krev, err := crypto.GenerateKey()
+	assert.Nil(t, err)
+	krevPub := krev.Public().(*ecdsa.PublicKey)
+	if debug {
+		fmt.Println("krev", common3.HexEncode(crypto.CompressPubkey(krevPub)))
+	}
+
+	idAddr, proofKOp, err := idsrv.CreateIdGenesis(kopPub, krecPub, krevPub)
+	assert.Nil(t, err)
+
+	idAddr2, err := CalculateIdGenesis(kopPub, krecPub, krevPub)
+	assert.Nil(t, err)
+	assert.Equal(t, idAddr, idAddr2)
+
+	proofKOpVerified, err := core.VerifyProofClaim(relayAddr, proofKOp)
+	assert.Nil(t, err)
+	assert.True(t, proofKOpVerified)
+}
+
+func TestCreateIdGenesisHardcoded(t *testing.T) {
+	idsrv := initializeIdService(t)
+
+	kopStr := "0x037e211781efef4687e78be4fb008768acca8101b6f1f7ea099599f02a8813f386"
+	krecStr := "0x03f9737be33b5829e3da80160464b2891277dae7d7c23609f9bb34bd4ede397bbf"
+	krevStr := "0x02d2da59d3022b4c1589e4910baa6cbaddd01f95ed198fdc3068d9dc1fb784a9a4"
+
+	kopBytes, err := common3.HexDecode(kopStr)
+	assert.Nil(t, err)
+	kopPub, err := crypto.DecompressPubkey(kopBytes[:])
+	assert.Nil(t, err)
+
+	krecBytes, err := common3.HexDecode(krecStr)
+	assert.Nil(t, err)
+	krecPub, err := crypto.DecompressPubkey(krecBytes[:])
+	assert.Nil(t, err)
+
+	krevBytes, err := common3.HexDecode(krevStr)
+	assert.Nil(t, err)
+	krevPub, err := crypto.DecompressPubkey(krevBytes[:])
+	assert.Nil(t, err)
+
+	idAddr, proofKOp, err := idsrv.CreateIdGenesis(kopPub, krecPub, krevPub)
+	assert.Nil(t, err)
+	if debug {
+		fmt.Println("idAddr", idAddr)
+		fmt.Println("idAddr (hex)", idAddr.String())
+	}
+	assert.Equal(t, "0xfC681EBF000EbBAA4EbE287f2bA1BC151249aB11", idAddr.String())
+
+	idAddr2, err := CalculateIdGenesis(kopPub, krecPub, krevPub)
+	assert.Nil(t, err)
+	assert.Equal(t, idAddr, idAddr2)
+
+	proofKOpVerified, err := core.VerifyProofClaim(relayAddr, proofKOp)
+	assert.Nil(t, err)
+	assert.True(t, proofKOpVerified)
 }


### PR DESCRIPTION
adding create genesis identity merkle

Add CreateIdGenesis & CalculateIdGenesis, Add endpoint handler for CreateIdGenesis

Add proof of kOp when creating identity genesis merkletree