### PR TITLE
Add ClaimAuthorizeService

### DIFF
--- a/core/claim.go
+++ b/core/claim.go
@@ -53,7 +53,7 @@ func GetClaimTypeVersionFromData(d *merkletree.Data) (c ClaimType, v uint32) {
 	return c, v
 }
 
-// HashString takes the first 31 bytes of a hash applied to name.
+// HashString takes the first 31 bytes of a hash applied to string
 func HashString(s string) (stringHashed [248 / 8]byte) {
 	hash := utils.HashBytes([]byte(s))
 	copy(stringHashed[:], hash[len(hash)-248/8:])
@@ -468,25 +468,51 @@ func (c *ClaimLinkObjectIdentity) Type() ClaimType {
 	return *ClaimTypeLinkObjectIdentity
 }
 
+// ServiceType
+var (
+	// ServiceTypeRelay is the type for authorize Relays
+	ServiceTypeRelay = NewServiceType(0)
+	// ServiceTypeNotificationsServer is the type for authorize Notification Server
+	ServiceTypeNotificationsServer = NewServiceType(1)
+	// ServiceTypeDiscoveryNode is the type for authorize DiscoveryNode
+	ServiceTypeDiscoveryNode = NewServiceType(2)
+)
+
+// ServiceTypeLen is the length in bytes of the type of the Services
+const ServiceTypeLen = 64 / 8
+
+// ServiceType is the type used to store a claim type.
+type ServiceType [ServiceTypeLen]byte
+
+// NewServiceType to set type of authorized services
+func NewServiceType(num uint64) *ServiceType {
+	st := ServiceType{}
+	binary.BigEndian.PutUint64(st[:], num)
+	return &st
+}
+
 // ClaimAuthorizeService is a claim to authorize a Service for the identity that performs the claim
 type ClaimAuthorizeService struct {
 	// Version is the claim version.
 	Version uint32
+	// ServiceType is the type of the authorized service
+	ServiceType *ServiceType
 	// ServiceAddr is the hash of the addr
 	ServiceAddr [248 / 8]byte
 	// ServicePubK is the hash of the pubK
 	ServicePubK [248 / 8]byte
-	// ServiceDomain is the hash of the domain
-	ServiceDomain [248 / 8]byte
+	// ServiceUrl is the hash of the domain
+	ServiceUrl [248 / 8]byte
 }
 
 // NewClaimAuthorizeService returns a ClaimAuthorizeService with the provided data.
-func NewClaimAuthorizeService(serviceAddr, servicePubK, serviceDomain string) *ClaimAuthorizeService {
+func NewClaimAuthorizeService(serviceType *ServiceType, serviceAddr, servicePubK, serviceUrl string) *ClaimAuthorizeService {
 	return &ClaimAuthorizeService{
-		Version:       0,
-		ServiceAddr:   HashString(serviceAddr),
-		ServicePubK:   HashString(servicePubK),
-		ServiceDomain: HashString(serviceDomain),
+		Version:     0,
+		ServiceType: serviceType,
+		ServiceAddr: HashString(serviceAddr),
+		ServicePubK: HashString(servicePubK),
+		ServiceUrl:  HashString(serviceUrl),
 	}
 }
 
@@ -494,9 +520,12 @@ func NewClaimAuthorizeService(serviceAddr, servicePubK, serviceDomain string) *C
 func NewClaimAuthorizeServiceFromEntry(e *merkletree.Entry) *ClaimAuthorizeService {
 	c := &ClaimAuthorizeService{}
 	_, c.Version = getClaimTypeVersion(e)
+	var serviceType [64 / 8]byte
+	copyFromElemBytes(serviceType[:], ClaimTypeVersionLen, &e.Data[3])
+	c.ServiceType = NewServiceType(binary.BigEndian.Uint64(serviceType[:]))
 	copyFromElemBytes(c.ServiceAddr[:], 0, &e.Data[2])
 	copyFromElemBytes(c.ServicePubK[:], 0, &e.Data[1])
-	copyFromElemBytes(c.ServiceDomain[:], 0, &e.Data[0])
+	copyFromElemBytes(c.ServiceUrl[:], 0, &e.Data[0])
 	return c
 }
 
@@ -504,9 +533,10 @@ func NewClaimAuthorizeServiceFromEntry(e *merkletree.Entry) *ClaimAuthorizeServi
 func (c *ClaimAuthorizeService) Entry() *merkletree.Entry {
 	e := &merkletree.Entry{}
 	setClaimTypeVersion(e, c.Type(), c.Version)
+	copyToElemBytes(&e.Data[3], ClaimTypeVersionLen, c.ServiceType[:])
 	copyToElemBytes(&e.Data[2], 0, c.ServiceAddr[:])
 	copyToElemBytes(&e.Data[1], 0, c.ServicePubK[:])
-	copyToElemBytes(&e.Data[0], 0, c.ServiceDomain[:])
+	copyToElemBytes(&e.Data[0], 0, c.ServiceUrl[:])
 	return e
 }
 

--- a/core/claim_test.go
+++ b/core/claim_test.go
@@ -246,7 +246,7 @@ func TestClaimAuthorizeService(t *testing.T) {
 		0x39, 0x39, 0x39, 0x39, 0x39, 0x39, 0x39, 0x39,
 		0x39, 0x39, 0x39, 0x3a})
 	pubKstr := "af048ddcc131d526699d928e8b8548c5c85fb7d407fc408bb543e4e58f305347f67942a7e56d7dc90bbcecca865f2fbde3118c91516594262f62857136f71dbc"
-	c0 := NewClaimAuthorizeService(ethAddr.Hex(), pubKstr, "relay.iden3.io")
+	c0 := NewClaimAuthorizeService(ServiceTypeRelay, ethAddr.Hex(), pubKstr, "relay.iden3.io")
 	e := c0.Entry()
 	assert.Equal(t,
 		"0x134bb5a379706bc9574bee7b0d6850a5fa0a7e324a6b9377ed28ee7444f3d0ce",
@@ -266,6 +266,7 @@ func TestClaimAuthorizeService(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, c0, c1)
 	assert.Equal(t, c0, c2)
+	assert.Equal(t, c0.ServiceType, ServiceTypeRelay)
 }
 
 func dataTestOutput(d *merkletree.Data) {

--- a/core/claim_test.go
+++ b/core/claim_test.go
@@ -239,6 +239,35 @@ func TestClaimLinkObjectIdentity(t *testing.T) {
 	assert.Equal(t, claim, c2)
 }
 
+func TestClaimAuthorizeService(t *testing.T) {
+	// ClaimAuthorizeService
+	ethAddr := common.BytesToAddress([]byte{
+		0x39, 0x39, 0x39, 0x39, 0x39, 0x39, 0x39, 0x39,
+		0x39, 0x39, 0x39, 0x39, 0x39, 0x39, 0x39, 0x39,
+		0x39, 0x39, 0x39, 0x3a})
+	pubKstr := "af048ddcc131d526699d928e8b8548c5c85fb7d407fc408bb543e4e58f305347f67942a7e56d7dc90bbcecca865f2fbde3118c91516594262f62857136f71dbc"
+	c0 := NewClaimAuthorizeService(ethAddr.Hex(), pubKstr, "relay.iden3.io")
+	e := c0.Entry()
+	assert.Equal(t,
+		"0x134bb5a379706bc9574bee7b0d6850a5fa0a7e324a6b9377ed28ee7444f3d0ce",
+		e.HIndex().Hex())
+	assert.Equal(t,
+		"0x14db3569b8a287c5142c99f697428addd607b52c2a470a96aff6ac98e4a445e8",
+		e.HValue().Hex())
+	dataTestOutput(&e.Data)
+	assert.Equal(t, ""+
+		"00f3b1c89978c483ef94f9ecff889cbef9db68036f3b2dc251e72b7960b8529d"+
+		"00f28abb0b5b73fdcc8eed8e707f33d8dd9b50b3e2c6e1957a585903ae3b729a"+
+		"00f54d900e54dfb5d19c0e19e5e3abca0d744fee18b72cb8b9cc05f655495983"+
+		"0000000000000000000000000000000000000000000000000000000000000006",
+		e.Data.String())
+	c1 := NewClaimAuthorizeServiceFromEntry(e)
+	c2, err := NewClaimFromEntry(e)
+	assert.Nil(t, err)
+	assert.Equal(t, c0, c1)
+	assert.Equal(t, c0, c2)
+}
+
 func dataTestOutput(d *merkletree.Data) {
 	if !debug {
 		return

--- a/services/signedpacketsrv/service.go
+++ b/services/signedpacketsrv/service.go
@@ -156,7 +156,7 @@ func (ss *Service) VerifyIdenAssertV01(nonceDb *core.NonceDb, origin string,
 	if !ok {
 		return nil, fmt.Errorf("Invalid claim type in form.proofAssignName.leaf")
 	}
-	if core.HashName(form.EthName) != claimAssignName.NameHash {
+	if core.HashString(form.EthName) != claimAssignName.NameHash {
 		return nil, fmt.Errorf("Assign Name claim name doesn't match with form.ethName")
 	}
 	if jws.Header.Issuer != claimAssignName.IdAddr {


### PR DESCRIPTION
Add ClaimAuthorizeService, that is a claim to authorize a Service for the identity that performs the claim.

```
e_3: [ 64  bits] claim type
     [ 32  bits] version
     [ 157 bits] 0
e_2: [ 248 bits] Hash_k(addr)
     [ 5   bits] 0
e_1: [ 248 bits] Hash_k(pubK)
     [ 5   bits] 0
e_0: [ 248 bits] Hash_k(domain)
     [ 5   bits] 0
```
Where `hash` is the Keccak(input_string)[-248/8:]
```
[0 | Hash_k(domain)][0 | Hash_k(pubK)][0 | Hash_k(addr)][0 | ver | type]
      e0                    e1              e2                  e3
```

This claim is used to authorize services to act for the identity that performs the claim, for example, with this claim type, an identity can authorize a Relay, a NotificationsServer, etc to act as their authorized services.
Also, when the identity is discovered through the discovery-protocol, will be provided the proofs of this claim, so a requester can verifiy that a service is authorized by the identity in the identity's merkletree.

