### PR TITLE
add ClaimEthId

### DIFF
--- a/core/claim.go
+++ b/core/claim.go
@@ -96,6 +96,10 @@ var (
 	ClaimTypeLinkObjectIdentity = NewClaimTypeNum(5)
 	// ClaimTypeAuthorizeService is a claim type to authorize a Service for the identity that performs the claim
 	ClaimTypeAuthorizeService = NewClaimTypeNum(6)
+	// ClaimTypeNonce is a claim used to increment the tree nonce to modify the root hash
+	ClaimTypeNonce = NewClaimTypeNum(7)
+	// ClaimTypeEthId is a claim type to autorize an Eth Address to be used as Id
+	ClaimTypeEthId = NewClaimTypeNum(8)
 )
 
 // ClaimVersionLen is the length in bytes of the version in a claim.
@@ -545,6 +549,52 @@ func (c *ClaimAuthorizeService) Type() ClaimType {
 	return *ClaimTypeAuthorizeService
 }
 
+// ClaimEthId is a claim to authorize a public key for signing.
+type ClaimEthId struct {
+	// Version is the claim version.
+	Version uint32
+
+	// Addr is the EthId that will use this identity in the ethereum blockchain
+	Address common.Address
+
+	// IdentityFactory specifies that the ClaimEthId.Address is an smartcontract, and how this identity is created. It can be just an identitied of the method, or an smartcontract that creates the identity.
+	// IDEN3 specifies the contract address 0x9827348723984729834234 as the factory for its contrafactual identities
+	// If 0x000.0000, means that is not using an identity creator, and the identity is always available.
+	IdentityFactory common.Address
+}
+
+// NewClaimEthId returns a ClaimEthId
+func NewClaimEthId(addr, identityFactory common.Address) *ClaimEthId {
+	return &ClaimEthId{
+		Version:         0,
+		Address:         addr,
+		IdentityFactory: identityFactory,
+	}
+}
+
+// NewClaimEthId deserializes a ClaimEthId from an Entry.
+func NewClaimEthIdFromEntry(e *merkletree.Entry) *ClaimEthId {
+	c := &ClaimEthId{}
+	_, c.Version = getClaimTypeVersion(e)
+	copyFromElemBytes(c.Address[:], 0, &e.Data[2])
+	copyFromElemBytes(c.IdentityFactory[:], 0, &e.Data[1])
+	return c
+}
+
+// Entry serializes the claim into an Entry.
+func (c *ClaimEthId) Entry() *merkletree.Entry {
+	e := &merkletree.Entry{}
+	setClaimTypeVersion(e, c.Type(), c.Version)
+	copyToElemBytes(&e.Data[2], 0, c.Address[:])
+	copyToElemBytes(&e.Data[1], 0, c.IdentityFactory[:])
+	return e
+}
+
+// Type returns the ClaimType of the claim.
+func (c *ClaimEthId) Type() ClaimType {
+	return *ClaimTypeEthId
+}
+
 // NewClaimFromEntry deserializes a valid claim type into a Claim.
 func NewClaimFromEntry(e *merkletree.Entry) (merkletree.Entrier, error) {
 	claimType, _ := getClaimTypeVersion(e)
@@ -568,6 +618,9 @@ func NewClaimFromEntry(e *merkletree.Entry) (merkletree.Entrier, error) {
 		return c, nil
 	case *ClaimTypeAuthorizeService:
 		c := NewClaimAuthorizeServiceFromEntry(e)
+		return c, nil
+	case *ClaimTypeEthId:
+		c := NewClaimEthIdFromEntry(e)
 		return c, nil
 	default:
 		return nil, ErrInvalidClaimType

--- a/core/claim_test.go
+++ b/core/claim_test.go
@@ -281,6 +281,27 @@ func dataTestOutput(d *merkletree.Data) {
 	fmt.Println(s.String())
 }
 
+func TestClaimEthId(t *testing.T) {
+	ethId := common.HexToAddress("0xe0fbce58cfaa72812103f003adce3f284fe5fc7c")
+	identityFactoryAddr := common.HexToAddress("0x66D0c2F85F1B717168cbB508AfD1c46e07227130")
+
+	c0 := NewClaimEthId(ethId, identityFactoryAddr)
+
+	c1 := NewClaimEthIdFromEntry(c0.Entry())
+	c2, err := NewClaimFromEntry(c0.Entry())
+	assert.Nil(t, err)
+	assert.Equal(t, c0, c1)
+	assert.Equal(t, c0, c2)
+
+	assert.Equal(t, c0.Address, ethId)
+	assert.Equal(t, c0.IdentityFactory, identityFactoryAddr)
+	assert.Equal(t, c0.Address, c1.Address)
+	assert.Equal(t, c0.IdentityFactory, c1.IdentityFactory)
+
+	assert.Equal(t, c0.Entry().Bytes(), c1.Entry().Bytes())
+	assert.Equal(t, c0.Entry().Bytes(), c2.Entry().Bytes())
+}
+
 // TODO: Update to new claim spec.
 //func TestForwardingInterop(t *testing.T) {
 //


### PR DESCRIPTION
New Claim type for the specification of the identity.

```go
type ClaimEthId struct {
	// Version is the claim version
	Version uint32
	
	// Addr is the EthId that will use this identity in the ethereum blockchain
	Address	common.Address

	// IdentityFactory specifies that the ClaimEthId.Address is an smartcontract, and how this identity is created. It can be just an identitied of the method, or an smartcontract that creates the identity.
	// IDEN3 specifies the contract 0x9827348723984729834234 as the factory for its contrafactual identities
	// If 0x000.0000, means that is not using an identity creator, and the identity is always available.
	IdentityFactory common.Address
}
```

```
e_3: [ 64  bits] claim type
     [ 32  bits] version
     [ 157 bits] 0
e_2: [ 160 bits] eth address
     [ 93   bits] 0
e_1: [ 160 bits] identity factory
     [ 93  bits] 0
e_0: 0
```
```
0 <---> N bytes
[0][0 | id factory][0 | eth addr][0 | ver | type]
e0    	  e1             e2              e3
```