### PR TITLE
add ϕ_min id spec (predicate of ITF)

### DIFF
--- a/core/id.go
+++ b/core/id.go
@@ -19,7 +19,7 @@ var (
 	TypeBJM7 = [2]byte{0x00, 0x00}
 
 	// TypeS2M7 specifies the S2-M7
-	// - first 2 bytes: `00000000 00000010`
+	// - first 2 bytes: `00000000 00000100`
 	// - curve of k_op: secp256k1
 	// - hash function: `MIMC7`
 	TypeS2M7 = [2]byte{0x00, 0x04}
@@ -89,7 +89,7 @@ func IDFromBytes(b []byte) (ID, error) {
 	return id, nil
 }
 
-// DecomposeID returns
+// DecomposeID returns type, genesis and checksum from an ID
 func DecomposeID(id ID) ([2]byte, [27]byte, [2]byte, error) {
 	var typ [2]byte
 	var genesis [27]byte

--- a/core/id_test.go
+++ b/core/id_test.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"bytes"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -137,7 +136,5 @@ func TestCalculateIdGenesis(t *testing.T) {
 		fmt.Println("idAddr", idAddr)
 		fmt.Println("idAddr (hex)", idAddr.String())
 	}
-	fmt.Println("idAddr", hex.EncodeToString(idAddr.Bytes()))
-	fmt.Println("idAddr (hex)", idAddr.String())
 	assert.Equal(t, "1pnWU7Jdr4yLxp1azs1r1PpvfErxKGRQdcLBZuq3Z", idAddr.String())
 }

--- a/core/proof_test.go
+++ b/core/proof_test.go
@@ -52,3 +52,149 @@ func TestProof(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, verified)
 }
+
+func TestGetPredicateProof(t *testing.T) {
+	dir, err := ioutil.TempDir("", "db")
+	assert.Nil(t, err)
+	sto, err := db.NewLevelDbStorage(dir, false)
+	assert.Nil(t, err)
+
+	mt, err := merkletree.NewMerkleTree(sto, 140)
+	assert.Nil(t, err)
+
+	idAddr0, err := IDFromString("1pnWU7Jdr4yLxp1azs1r1PpvfErxKGRQdcLBZuq3Z")
+	assert.Nil(t, err)
+	rootKey0 := merkletree.Hash(merkletree.ElemBytes{
+		0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
+		0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
+		0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
+		0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0a})
+	claim0 := NewClaimSetRootKey(idAddr0, rootKey0)
+	err = mt.Add(claim0.Entry())
+	assert.Nil(t, err)
+	oldRoot := mt.RootKey()
+
+	mtp, err := GetClaimProofByHi(mt, claim0.Entry().HIndex())
+	assert.Nil(t, err)
+
+	relayAddr := common.Address{}
+	verified, err := VerifyProofClaim(relayAddr, mtp)
+	assert.Nil(t, err)
+	assert.True(t, verified)
+
+	p, err := GetPredicateProof(mt, oldRoot, claim0.Entry().HIndex())
+	assert.Nil(t, err)
+
+	assert.True(t, merkletree.VerifyProof(mt.RootKey(), p.MtpExist, claim0.Entry().HIndex(), claim0.Entry().HValue()))
+
+	claim0Entry := GetNextVersionEntry(claim0.Entry())
+	assert.True(t, merkletree.VerifyProof(mt.RootKey(), p.MtpNonExistNextVersion, claim0Entry.HIndex(), claim0Entry.HValue()))
+
+	assert.True(t, merkletree.VerifyProof(mt.RootKey(), p.MtpNonExistInOldRoot, claim0.Entry().HIndex(), claim0.Entry().HValue()))
+}
+
+func TestGenerateAndVerifyPredicateProofOfClaimVersion0(t *testing.T) {
+	dir, err := ioutil.TempDir("", "db")
+	assert.Nil(t, err)
+	sto, err := db.NewLevelDbStorage(dir, false)
+	assert.Nil(t, err)
+
+	mt, err := merkletree.NewMerkleTree(sto, 140)
+	assert.Nil(t, err)
+
+	idAddr0, err := IDFromString("1pnWU7Jdr4yLxp1azs1r1PpvfErxKGRQdcLBZuq3Z")
+	assert.Nil(t, err)
+	rootKey0 := merkletree.Hash(merkletree.ElemBytes{
+		0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
+		0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
+		0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
+		0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0a})
+	claim0 := NewClaimSetRootKey(idAddr0, rootKey0)
+	// oldRoot is the root before adding the claim that we want to prove that we added correctly
+	oldRoot := mt.RootKey()
+	err = mt.Add(claim0.Entry())
+	assert.Nil(t, err)
+
+	predicateProof, err := GetPredicateProof(mt, oldRoot, claim0.Entry().HIndex())
+	assert.Nil(t, err)
+
+	_, v := getClaimTypeVersion(predicateProof.LeafEntry)
+	assert.Equal(t, uint32(0), v)
+	assert.Equal(t, predicateProof.OldRoot.Hex(), "0x0000000000000000000000000000000000000000000000000000000000000000")
+	assert.NotEqual(t, predicateProof.OldRoot.Hex(), predicateProof.Root.Hex())
+
+	assert.True(t, VerifyPredicateProof(predicateProof))
+}
+
+func TestGenerateAndVerifyPredicateProofOfClaimVersion1(t *testing.T) {
+	dir, err := ioutil.TempDir("", "db")
+	assert.Nil(t, err)
+	sto, err := db.NewLevelDbStorage(dir, false)
+	assert.Nil(t, err)
+
+	mt, err := merkletree.NewMerkleTree(sto, 140)
+	assert.Nil(t, err)
+
+	idAddr0, err := IDFromString("1pnWU7Jdr4yLxp1azs1r1PpvfErxKGRQdcLBZuq3Z")
+	assert.Nil(t, err)
+	rootKey0 := merkletree.Hash(merkletree.ElemBytes{
+		0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
+		0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
+		0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
+		0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0a})
+	claim0 := NewClaimSetRootKey(idAddr0, rootKey0)
+	err = mt.Add(claim0.Entry())
+	assert.Nil(t, err)
+
+	// add the same claim, but with version 1
+	claim1 := &ClaimSetRootKey{
+		Version: claim0.Version + 1,
+		Era:     0,
+		IdAddr:  claim0.IdAddr,
+		RootKey: claim0.RootKey,
+	}
+	err = mt.Add(claim1.Entry())
+	assert.Nil(t, err)
+	// add the same claim, but with version 2
+	claim2 := &ClaimSetRootKey{
+		Version: claim1.Version + 1,
+		Era:     0,
+		IdAddr:  claim0.IdAddr,
+		RootKey: claim0.RootKey,
+	}
+	err = mt.Add(claim2.Entry())
+	assert.Nil(t, err)
+
+	// oldRoot is the root before adding the claim that we want to prove that we added correctly
+	oldRoot := mt.RootKey()
+
+	// add the same claim, but with version 3
+	claim3 := &ClaimSetRootKey{
+		Version: claim2.Version + 1,
+		Era:     0,
+		IdAddr:  claim0.IdAddr,
+		RootKey: claim0.RootKey,
+	}
+	err = mt.Add(claim3.Entry())
+	assert.Nil(t, err)
+
+	// expect error, as we are trying to generate a proof of a claim which one the next version
+	_, err = GetPredicateProof(mt, oldRoot, claim0.Entry().HIndex())
+	assert.Equal(t, err, ErrRevokedClaim)
+	_, err = GetPredicateProof(mt, oldRoot, claim1.Entry().HIndex())
+	assert.Equal(t, err, ErrRevokedClaim)
+	_, err = GetPredicateProof(mt, oldRoot, claim2.Entry().HIndex())
+	assert.Equal(t, err, ErrRevokedClaim)
+
+	predicateProof, err := GetPredicateProof(mt, oldRoot, claim3.Entry().HIndex())
+	assert.Nil(t, err)
+
+	_, v := getClaimTypeVersion(predicateProof.LeafEntry)
+	assert.Equal(t, uint32(3), v)
+	assert.Equal(t, predicateProof.OldRoot.Hex(), "0x22e52a06ab4c4824377859745863e4d306b74b451ec9d09637a4d0c0ad14667e")
+	assert.NotEqual(t, predicateProof.OldRoot.Hex(), predicateProof.Root.Hex())
+
+	assert.Equal(t, predicateProof.MtpNonExistInOldRoot.Siblings[0], predicateProof.MtpExist.Siblings[0])
+
+	assert.True(t, VerifyPredicateProof(predicateProof))
+}


### PR DESCRIPTION
Predicate generation & verification.

Ensures that the MerkleTree is updated incrementally by:
checking that:
- 0: tree is updated incrementally
    - claim position was empty in oldRoot
- 1: claim is added correctly
    - claim position contains the claim in currentRoot
- 2: claim is not revocated
    - claim (version+1) is empty in currentRoot
in case that the claim version != 0:
- 3: claim is at the expected version
    - claim (version-1) exist in oldRoot
- 4: current version is incremental from the last one
    - siblings of check_0 are inside of check_1